### PR TITLE
fix: preserve default options when adding new translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "node-plop": "^0.32.0",
         "parcel": "^2.12.0",
         "plop": "^4.0.1",
+        "rollup-plugin-copy": "^3.5.0",
         "sass": "^1.75.0",
         "semantic-release": "^23.1.1",
         "semantic-release-monorepo": "^8.0.2",
@@ -6138,6 +6139,15 @@
       "integrity": "sha512-2N93vadEGDFhASTIRbizbl4bNqpMOId5zZfj6hHqYZfEzEfO9onnU4Im8xvzo8uudySDveDHBOOSlTWf38ErfQ==",
       "dev": true
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -8048,6 +8058,12 @@
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
     },
     "node_modules/combined-stream": {
@@ -18915,6 +18931,91 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-copy": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
+      "integrity": "sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/globby": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.0.tgz",
@@ -23505,7 +23606,7 @@
     },
     "packages/pillarbox-playlist": {
       "name": "@srgssr/pillarbox-playlist",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@srgssr/pillarbox-web": "^1.12.1"
@@ -23516,7 +23617,7 @@
     },
     "packages/skip-button": {
       "name": "@srgssr/skip-button",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "peerDependencies": {
         "@srgssr/pillarbox-web": "^1.12.1"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "node-plop": "^0.32.0",
     "parcel": "^2.12.0",
     "plop": "^4.0.1",
+    "rollup-plugin-copy": "^3.5.0",
     "sass": "^1.75.0",
     "semantic-release": "^23.1.1",
     "semantic-release-monorepo": "^8.0.2",

--- a/packages/pillarbox-playlist/src/lang/index.js
+++ b/packages/pillarbox-playlist/src/lang/index.js
@@ -1,12 +1,19 @@
-import * as de from './de.json';
-import * as en from './en.json';
-import * as fr from './fr.json';
-import * as it from './it.json';
-import * as rm from './rm.json';
+import de from './de.json';
+import en from './en.json';
+import fr from './fr.json';
+import it from './it.json';
+import rm from './rm.json';
 import videojs from 'video.js';
 
-videojs.addLanguage('de', de);
-videojs.addLanguage('en', en);
-videojs.addLanguage('fr', fr);
-videojs.addLanguage('it', it);
-videojs.addLanguage('rm', rm);
+function extendLanguage(code, data) {
+  videojs.addLanguage(code, {
+    ...videojs.options.language[code] ?? {},
+    ...data
+  });
+}
+
+extendLanguage('de', de);
+extendLanguage('en', en);
+extendLanguage('fr', fr);
+extendLanguage('it', it);
+extendLanguage('rm', rm);

--- a/packages/pillarbox-playlist/test/language.spec.js
+++ b/packages/pillarbox-playlist/test/language.spec.js
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../src/lang';
+import pillarbox from '@srgssr/pillarbox-web';
+
+window.HTMLMediaElement.prototype.load = () => {};
+
+describe('Language', () => {
+  let player;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<video id="test-video" class="video-js"></video>';
+
+    const videoElement = document.querySelector('#test-video');
+
+    player = pillarbox(videoElement);
+  });
+
+  afterEach(() => {
+    player.dispose();
+    vi.resetAllMocks();
+  });
+
+  it('should use the correct French translations', () => {
+    // When
+    player.language('fr');
+
+    // Then
+    expect(player.localize('Play')).toBe('Lecture');
+    expect(player.localize('Shuffle')).toBe('Mélanger');
+  });
+});

--- a/packages/pillarbox-playlist/vite.config.ui.js
+++ b/packages/pillarbox-playlist/vite.config.ui.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import babel from '@rollup/plugin-babel';
+import copy from 'rollup-plugin-copy';
 
 /**
  * Vite's configuration for the lib build.
@@ -30,10 +31,16 @@ export default defineConfig({
           entryFileNames: 'pillarbox-playlist-ui.cjs'
         }
       ],
-      plugins: [babel({
-        babelHelpers: 'bundled',
-        exclude: 'node_modules/**'
-      })]
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          exclude: 'node_modules/**'
+        }),
+        copy({
+          targets: [{ src: 'src/lang/*.json', dest: 'dist/lang' }],
+          hook: 'writeBundle'
+        })
+      ]
     }
   }
 });

--- a/packages/skip-button/src/lang/index.js
+++ b/packages/skip-button/src/lang/index.js
@@ -1,12 +1,19 @@
-import * as de from './de.json';
-import * as en from './en.json';
-import * as fr from './fr.json';
-import * as it from './it.json';
-import * as rm from './rm.json';
+import de from './de.json';
+import en from './en.json';
+import fr from './fr.json';
+import it from './it.json';
+import rm from './rm.json';
 import pillarbox from '@srgssr/pillarbox-web';
 
-pillarbox.addLanguage('de', de);
-pillarbox.addLanguage('en', en);
-pillarbox.addLanguage('fr', fr);
-pillarbox.addLanguage('it', it);
-pillarbox.addLanguage('rm', rm);
+function extendLanguage(code, data) {
+  pillarbox.addLanguage(code, {
+    ...pillarbox.options.language[code] ?? {},
+    ...data
+  });
+}
+
+extendLanguage('de', de);
+extendLanguage('en', en);
+extendLanguage('fr', fr);
+extendLanguage('it', it);
+extendLanguage('rm', rm);

--- a/packages/skip-button/test/language.spec.js
+++ b/packages/skip-button/test/language.spec.js
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../src/lang';
+import pillarbox from '@srgssr/pillarbox-web';
+
+window.HTMLMediaElement.prototype.load = () => {};
+
+describe('Language', () => {
+  let player;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<video id="test-video" class="video-js"></video>';
+
+    const videoElement = document.querySelector('#test-video');
+
+    player = pillarbox(videoElement);
+  });
+
+  afterEach(() => {
+    player.dispose();
+    vi.resetAllMocks();
+  });
+
+  it('should use the correct French translations', () => {
+    // When
+    player.language('fr');
+
+    // Then
+    expect(player.localize('Play')).toBe('Lecture');
+    expect(player.localize('Skip credits')).toBe('Passer');
+  });
+});

--- a/packages/skip-button/vite.config.lib.js
+++ b/packages/skip-button/vite.config.lib.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import babel from '@rollup/plugin-babel';
+import copy from 'rollup-plugin-copy';
 
 /**
  * Vite's configuration for the lib build.
@@ -19,10 +20,16 @@ export default defineConfig({
     },
     rollupOptions: {
       external: ['@srgssr/pillarbox-web'],
-      plugins: [babel({
-        babelHelpers: 'bundled',
-        exclude: 'node_modules/**'
-      })]
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          exclude: 'node_modules/**'
+        }),
+        copy({
+          targets: [{ src: 'src/lang/*.json', dest: 'dist/lang' }],
+          hook: 'writeBundle'
+        })
+      ]
     }
   }
 });

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -46,7 +46,10 @@ export default function(plop) {
         templateFiles: './template/**',
         globOptions: {
           dot: true,
-          ignore: !data.wantLocalization ? '**/src/lang/**' : undefined
+          ignore: !data.wantLocalization ? [
+            '**/src/lang/**',
+            '**/test/language.spec.js.hbs'
+          ] : undefined
         },
         data: {
           importAlias: data.platform === 'pillarbox' ? '@srgssr/pillarbox-web' : 'video.js'

--- a/scripts/template/src/lang/index.js.hbs
+++ b/scripts/template/src/lang/index.js.hbs
@@ -1,12 +1,19 @@
-import * as de from './de.json';
-import * as en from './en.json';
-import * as fr from './fr.json';
-import * as it from './it.json';
-import * as rm from './rm.json';
+import de from './de.json';
+import en from './en.json';
+import fr from './fr.json';
+import it from './it.json';
+import rm from './rm.json';
 import {{platform}} from '{{importAlias}}';
 
-{{platform}}.addLanguage('de', de);
-{{platform}}.addLanguage('en', en);
-{{platform}}.addLanguage('fr', fr);
-{{platform}}.addLanguage('it', it);
-{{platform}}.addLanguage('rm', rm);
+function extendLanguage(code, data) {
+  {{platform}}.addLanguage(code, {
+    ...{{platform}}.options.language[code] ?? {},
+    ...data
+  });
+}
+
+extendLanguage('de', de);
+extendLanguage('en', en);
+extendLanguage('fr', fr);
+extendLanguage('it', it);
+extendLanguage('rm', rm);

--- a/scripts/template/test/language.spec.js.hbs
+++ b/scripts/template/test/language.spec.js.hbs
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../src/lang';
+import pillarbox from '@srgssr/pillarbox-web';
+
+window.HTMLMediaElement.prototype.load = () => {};
+
+describe('Language', () => {
+  let player;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<video id="test-video" class="video-js"></video>';
+
+    const videoElement = document.querySelector('#test-video');
+
+    player = pillarbox(videoElement);
+  });
+
+  afterEach(() => {
+    player.dispose();
+    vi.resetAllMocks();
+  });
+
+  it('should use the correct French translations', () => {
+    // When
+    player.language('fr');
+
+    // Then
+    expect(player.localize('Play')).toBe('Lecture');
+  });
+});

--- a/scripts/template/vite.config.lib.js.hbs
+++ b/scripts/template/vite.config.lib.js.hbs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import babel from '@rollup/plugin-babel';
+import copy from 'rollup-plugin-copy';
 
 /**
  * Vite's configuration for the lib build.
@@ -19,10 +20,16 @@ export default defineConfig({
     },
     rollupOptions: {
       external: ['{{importAlias}}'],
-      plugins: [babel({
-        babelHelpers: 'bundled',
-        exclude: 'node_modules/**'
-      })]
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          exclude: 'node_modules/**'
+        }){{#if wantLocalization}},
+        copy({
+          targets: [{ src: 'src/lang/*.json', dest: 'dist/lang' }],
+           hook: 'writeBundle'
+        }){{/if}}
+      ]
     }
   }
 });


### PR DESCRIPTION
## Description

Refactored language modules to merge with existing default translations in `videojs.options.language`. This prevents overriding default configurations when calling `videojs.addLanguage`. Changes have been applied across all packages in the monorepo and the templates for the generation of new packages.

## Changes Made

- Preserve existing translations when adding package specific keys.
- Expose language files as assets into the final build.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.