### PR TITLE
docs: fix quick start link

### DIFF
--- a/packages/pillarbox-playlist/README.md
+++ b/packages/pillarbox-playlist/README.md
@@ -135,8 +135,8 @@ player.playlistPlugin().on('statechanged', ({ changes }) => {
 
 ## Contributing
 
-For detailed contribution guidelines, refer to the main project’s [README file][main-readme]. Please
-adhere to the specified guidelines.
+For detailed contribution guidelines, refer to our [Contributing guide][contributing-guide].
+Please adhere to the specified guidelines.
 
 ### Setting up a development server
 
@@ -171,5 +171,4 @@ http://localhost:4200/?language=fr
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more
 details.
 
-[main-readme]: ../../docs/README.md#Contributing
-[generate-token]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token
+[contributing-guide]: https://github.com/SRGSSR/pillarbox-web-suite/blob/main/docs/README.md#contributing

--- a/packages/pillarbox-playlist/README.md
+++ b/packages/pillarbox-playlist/README.md
@@ -19,7 +19,7 @@ npm install --save @srgssr/pillarbox-web @srgssr/pillarbox-playlist
 ```
 
 For instructions on setting up Pillarbox, see
-the [Quick Start guide](SRGSSR/pillarbox-web#quick-start).
+the [Quick Start guide](https://github.com/SRGSSR/pillarbox-web#quick-start).
 
 Once the player is installed you can activate the plugin as follows:
 

--- a/packages/pillarbox-playlist/package.json
+++ b/packages/pillarbox-playlist/package.json
@@ -11,7 +11,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://srgssr.github.io/pillarbox-web-suite/pillarbox-playlist",
+  "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/pillarbox-playlist#readme",
   "type": "module",
   "main": "dist/pillarbox-playlist.cjs",
   "module": "dist/pillarbox-playlist.js",

--- a/packages/skip-button/README.md
+++ b/packages/skip-button/README.md
@@ -42,8 +42,8 @@ To apply the default styling, add the following line to your CSS file:
 
 ## Contributing
 
-For detailed contribution guidelines, refer to the main project’s [README file][main-readme]. Please
-adhere to the specified guidelines.
+For detailed contribution guidelines, refer to our [Contributing guide][contributing-guide].
+Please adhere to the specified guidelines.
 
 ### Setting up a development server
 
@@ -79,6 +79,4 @@ http://localhost:4200/?language=fr&urn=urn:rts:video:14318206
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more
 details.
 
-[main-readme]: ../../docs/README.md#Contributing
-
-[generate-token]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token
+[contributing-guide]: https://github.com/SRGSSR/pillarbox-web-suite/blob/main/docs/README.md#contributing

--- a/packages/skip-button/README.md
+++ b/packages/skip-button/README.md
@@ -19,7 +19,7 @@ npm install --save @srgssr/pillarbox-web @srgssr/skip-button
 ```
 
 For instructions on setting up Pillarbox, see
-the [Quick Start guide](SRGSSR/pillarbox-web#quick-start).
+the [Quick Start guide](https://github.com/SRGSSR/pillarbox-web#quick-start).
 
 Once the player is installed you can activate the button as follows:
 

--- a/packages/skip-button/package.json
+++ b/packages/skip-button/package.json
@@ -11,7 +11,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://srgssr.github.io/pillarbox-web-suite/skip-button",
+  "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/skip-button#readme",
   "type": "module",
   "main": "dist/skip-button.cjs",
   "module": "dist/skip-button.js",

--- a/scripts/template/README.md.hbs
+++ b/scripts/template/README.md.hbs
@@ -20,7 +20,8 @@ npm install --save {{importAlias}} @srgssr/{{kebabCase name}}
 ```
 
 {{#ifEq platform 'pillarbox'}}
-For instructions on setting up Pillarbox, see the [Quick Start guide](SRGSSR/pillarbox-web#quick-start).
+For instructions on setting up Pillarbox, see
+the [Quick Start guide](https://github.com/SRGSSR/pillarbox-web#quick-start).
 
 {{/ifEq}}
 Once the player is installed you can activate the {{lowerCase type}} as follows:

--- a/scripts/template/README.md.hbs
+++ b/scripts/template/README.md.hbs
@@ -45,8 +45,8 @@ To apply the default styling, add the following line to your CSS file:
 
 ## Contributing
 
-For detailed contribution guidelines, refer to the main project’s [README file][main-readme]. Please
-adhere to the specified guidelines.
+For detailed contribution guidelines, refer to our [Contributing guide][contributing-guide].
+Please adhere to the specified guidelines.
 
 ### Setting up a development server
 
@@ -82,6 +82,4 @@ http://localhost:4200/?language=fr&urn=urn:rts:video:14318206
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more
 details.
 
-[main-readme]: ../../docs/README.md#Contributing
-
-[generate-token]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token
+[contributing-guide]: https://github.com/SRGSSR/pillarbox-web-suite/blob/main/docs/README.md#contributing

--- a/scripts/template/package.json.hbs
+++ b/scripts/template/package.json.hbs
@@ -10,7 +10,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://srgssr.github.io/pillarbox-web-suite/{{kebabCase name}}",
+  "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/{{kebabCase name}}#readme",
   "type": "module",
   "main": "dist/{{kebabCase name}}.cjs",
   "module": "dist/{{kebabCase name}}.js",


### PR DESCRIPTION
## Description

- Fixes all the links to the quick start guide of pillarbox-web.
- Makes the homepage point to the readme file in github for each individual package instead of the demo page for better discoverability.
- Fixes links to contributing guidelines.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
