### PR TITLE
fix: expose version on existing plugins and components

### DIFF
--- a/packages/pillarbox-playlist/src/pillarbox-playlist.js
+++ b/packages/pillarbox-playlist/src/pillarbox-playlist.js
@@ -1,4 +1,5 @@
 import videojs from 'video.js';
+import { version } from '../package.json';
 
 /**
  * @ignore
@@ -466,6 +467,10 @@ export class PillarboxPlaylist extends Plugin {
       items: JSON.stringify(this.items_),
       currentIndex: this.currentIndex_
     });
+  }
+
+  static get VERSION() {
+    return version;
   }
 }
 

--- a/packages/skip-button/src/skip-button.js
+++ b/packages/skip-button/src/skip-button.js
@@ -1,4 +1,5 @@
 import pillarbox from '@srgssr/pillarbox-web';
+import { version } from '../package.json';
 import './lang';
 
 /**
@@ -76,6 +77,7 @@ class SkipButton extends Button {
   }
 }
 
+SkipButton.VERSION = version;
 pillarbox.registerComponent('SkipButton', SkipButton);
 
 export default SkipButton;

--- a/packages/skip-button/src/skip-button.js
+++ b/packages/skip-button/src/skip-button.js
@@ -75,9 +75,12 @@ class SkipButton extends Button {
     this.controlText(text);
     this.show();
   }
+
+  static get VERSION() {
+    return version;
+  }
 }
 
-SkipButton.VERSION = version;
 pillarbox.registerComponent('SkipButton', SkipButton);
 
 export default SkipButton;

--- a/scripts/template/src/{{kebabCase name}}.js.hbs
+++ b/scripts/template/src/{{kebabCase name}}.js.hbs
@@ -22,9 +22,12 @@ class {{properCase name}} extends Plugin {
   constructor(player, options) {
     super(player, options);
   }
+
+  static get VERSION() {
+    return version;
+  }
 }
 
-{{properCase name}}.VERSION = version;
 {{platform}}.registerPlugin('{{camelCase name}}', {{properCase name}});
 {{else}}
 /**
@@ -54,9 +57,12 @@ class {{properCase name}} extends {{type}} {
   handleLanguagechange() {
     super.handleLanguagechange();
   }
+
+  static get VERSION() {
+    return version;
+  }
 }
 
-{{properCase name}}.VERSION = version;
 {{platform}}.registerComponent('{{properCase name}}', {{properCase name}});
 {{/ifEq}}
 

--- a/scripts/template/src/{{kebabCase name}}.js.hbs
+++ b/scripts/template/src/{{kebabCase name}}.js.hbs
@@ -1,4 +1,5 @@
 import {{platform}} from '{{importAlias}}';
+import { version } from '../package.json';
 {{#if wantLocalization}}import './lang';{{/if}}
 
 {{#ifEq type 'Plugin'}}
@@ -23,6 +24,7 @@ class {{properCase name}} extends Plugin {
   }
 }
 
+{{properCase name}}.VERSION = version;
 {{platform}}.registerPlugin('{{camelCase name}}', {{properCase name}});
 {{else}}
 /**
@@ -54,6 +56,7 @@ class {{properCase name}} extends {{type}} {
   }
 }
 
+{{properCase name}}.VERSION = version;
 {{platform}}.registerComponent('{{properCase name}}', {{properCase name}});
 {{/ifEq}}
 


### PR DESCRIPTION
## Description

Exposes the version in the package.json of each existing plugin and component. Modified the create script template so that the `VERSION` is automatically added on every new package.

- **Retrieve the version of a component:**
  ```javascript
  player.SkipButton.constructor.VERSION
  ```

- **Retrieve the version of a plugin:**
  ```javascript
  player.pillarboxPlaylist().version()
  ```

## Changes Made

- Updates create script template to include the version of the generated component or plugin.
- Expose the skip-button component version by adding a `VERSION` property to the constructor.
- Expose the playlist-plugin version by adding a `VERSION` property to the constructor.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
