### PR TITLE
chore(playlist-plugin): use dynamic repeat mode length in toggle calculation

### DIFF
--- a/packages/pillarbox-playlist/src/pillarbox-playlist.js
+++ b/packages/pillarbox-playlist/src/pillarbox-playlist.js
@@ -82,7 +82,7 @@ export class PillarboxPlaylist extends Plugin {
    *        If omitted, the repeat mode will cycle in order through: no repeat, repeat all and repeat one.
    */
   toggleRepeat(force = undefined) {
-    this.repeat = force ?? (this.repeat + 1) % 3;
+    this.repeat = force ?? (this.repeat + 1) % Object.keys(RepeatMode).length;
   }
 
   /**

--- a/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
+++ b/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
@@ -404,6 +404,28 @@ describe('PillarboxPlaylist', () => {
       expect(srcSpy).toHaveBeenLastCalledWith(playlist[0].sources);
       expect(posterSpy).toHaveBeenLastCalledWith(playlist[0].poster);
     });
+
+    it('should toggle repeat mode', () => {
+      pillarboxPlaylist.toggleRepeat(RepeatMode.NO_REPEAT);
+
+      pillarboxPlaylist.toggleRepeat();
+      expect(pillarboxPlaylist.repeat).toBe(RepeatMode.REPEAT_ALL);
+      expect(pillarboxPlaylist.isNoRepeatMode()).toBeFalsy();
+      expect(pillarboxPlaylist.isRepeatAllMode()).toBeTruthy();
+      expect(pillarboxPlaylist.isRepeatOneMode()).toBeFalsy();
+
+      pillarboxPlaylist.toggleRepeat();
+      expect(pillarboxPlaylist.repeat).toBe(RepeatMode.REPEAT_ONE);
+      expect(pillarboxPlaylist.isNoRepeatMode()).toBeFalsy();
+      expect(pillarboxPlaylist.isRepeatAllMode()).toBeFalsy();
+      expect(pillarboxPlaylist.isRepeatOneMode()).toBeTruthy();
+
+      pillarboxPlaylist.toggleRepeat();
+      expect(pillarboxPlaylist.repeat).toBe(RepeatMode.NO_REPEAT);
+      expect(pillarboxPlaylist.isNoRepeatMode()).toBeTruthy();
+      expect(pillarboxPlaylist.isRepeatAllMode()).toBeFalsy();
+      expect(pillarboxPlaylist.isRepeatOneMode()).toBeFalsy();
+    });
   });
 
   describe('shuffle', () => {


### PR DESCRIPTION
## Description

Replaced hardcoded value `3` to improve maintainability and adapt to changes in RepeatMode. See https://github.com/SRGSSR/pillarbox-web-suite/pull/33#pullrequestreview-2381337306

## Changes Made

- Added a test to ensure the change works as expected.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
