### PR TITLE
fix: update urls for custom domain setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://srgssr.github.io/pillarbox-web-suite",
+  "homepage": "https://plugins.pillarbox.ch",
   "type": "module",
   "workspaces": [
     "packages/*",

--- a/packages/skip-button/README.md
+++ b/packages/skip-button/README.md
@@ -2,7 +2,7 @@
 
 A custom component that extends the pillarbox-web player allowing users to skip certain parts of the
 video content, such as opening credits or end credits, by listening to
-the [`srgssr/interval` event](https://srgssr.github.io/pillarbox-web/api/tutorial-Events.html#srgssr%2Finterval-event).
+the [`srgssr/interval` event](https://web.pillarbox.ch/api/tutorial-Events.html#srgssr%2Finterval-event).
 
 ## Requirements
 


### PR DESCRIPTION
## Description

Use custom domain urls throughout the documentation.

## Changes Made

- Updated all URLs to the demo page to point to `demo.pillarbox.ch`
- Updated all API documentation URLs to point to `web.pillarbox.ch/api`
- Updated all URLs to the theme editor to point to `editor.pillarbox.ch`
- Updated all URLs to the web suite demo to point to `plugins.pillarbox.ch`
- Updated all URLs to the marketing page to point to `www.pillarbox.ch`
- Updated all URLs to the Android documentation page to point to `android.pillarbox.ch`

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
