### PR TITLE
fix(user-preferences): failed build step when the SCSS folder and file are missing

### DIFF
--- a/packages/user-preferences/scss/user-preferences.scss
+++ b/packages/user-preferences/scss/user-preferences.scss
@@ -1,0 +1,1 @@
+// empty file


### PR DESCRIPTION



## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

The package build does not work if the scss folder and the associated style file are not present.


## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->


- create scss folder
- create scss file and add a comment to satisfy the linter

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
