### PR TITLE
chore(create): allow opt-out of scss on new component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4166,6 +4166,10 @@
       "resolved": "packages/skip-button",
       "link": true
     },
+    "node_modules/@srgssr/toto": {
+      "resolved": "packages/toto",
+      "link": true
+    },
     "node_modules/@srgssr/user-preferences": {
       "resolved": "packages/user-preferences",
       "link": true
@@ -20847,9 +20851,17 @@
         "@srgssr/pillarbox-web": "^1.12.2"
       }
     },
+    "packages/toto": {
+      "name": "@srgssr/toto",
+      "version": "0.0.1",
+      "license": "MIT",
+      "peerDependencies": {
+        "@srgssr/pillarbox-web": "^1.12.1"
+      }
+    },
     "packages/user-preferences": {
       "name": "@srgssr/user-preferences",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@srgssr/pillarbox-web": "^1.14.1"

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -20,7 +20,7 @@ export default function(plop) {
       {
         type: 'list',
         name: 'type',
-        message: 'What type of the element would you like to create?',
+        message: 'What type of element would you like to create?',
         choices: [
           { name: 'Plugin \x1b[90m(Extend the player functionality or add new features)\x1b[0m', value: 'Plugin' },
           { name: 'Component \x1b[90m(Manipulate or display content within the player)\x1b[0m', value: 'Component' },
@@ -40,7 +40,14 @@ export default function(plop) {
       {
         type: 'confirm',
         name: 'wantLocalization',
-        message: 'Will your element support multiple languages?'
+        message: 'Will your element support multiple languages?',
+        default: true
+      },
+      {
+        type: 'confirm',
+        name: 'wantScss',
+        message: 'Will your element offer custom styles with SCSS?',
+        default: true
       }
     ],
     actions: data => [
@@ -51,10 +58,15 @@ export default function(plop) {
         templateFiles: './template/**',
         globOptions: {
           dot: true,
-          ignore: !data.wantLocalization ? [
-            '**/src/lang/**',
-            '**/test/language.spec.js.hbs'
-          ] : undefined
+          ignore: [
+            ...(!data.wantLocalization ? [
+              '**/src/lang/**',
+              '**/test/language.spec.js.hbs'
+            ] : []),
+            ...(!data.wantScss ? [
+              '**/scss/**'
+            ] : [])
+          ]
         },
         data: {
           currentYear: new Date().getFullYear(),

--- a/scripts/template/README.md.hbs
+++ b/scripts/template/README.md.hbs
@@ -37,12 +37,14 @@ const player = {{platform}}('my-player', { {{properCase name}}: true });
 {{/ifEq}}
 ```
 
+{{#if wantScss}}
 To apply the default styling, add the following line to your CSS file:
 
 ```css
 @import "@srgssr/{{kebabCase name}}/dist/{{kebabCase name}}.min.css";
 ```
 
+{{/if}}
 ## Contributing
 
 For detailed contribution guidelines, refer to our [Contributing guide][contributing-guide].

--- a/scripts/template/index.html.hbs
+++ b/scripts/template/index.html.hbs
@@ -22,8 +22,8 @@
 
 <script type="module">
   import '@srgssr/pillarbox-web/dist/pillarbox.min.css';
-  import pillarbox from '@srgssr/pillarbox-web';
-  import './scss/{{kebabCase name}}.scss';
+  import pillarbox from '@srgssr/pillarbox-web';{{#if wantScss}}
+  import './scss/{{kebabCase name}}.scss';{{/if}}
   import './src/{{kebabCase name}}.js';
 
   // Handle URL parameters

--- a/scripts/template/package.json.hbs
+++ b/scripts/template/package.json.hbs
@@ -13,8 +13,8 @@
   "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/{{kebabCase name}}#readme",
   "type": "module",
   "main": "dist/{{kebabCase name}}.cjs",
-  "module": "dist/{{kebabCase name}}.js",
-  "style": "./dist/{{kebabCase name}}.min.css",
+  "module": "dist/{{kebabCase name}}.js",{{#if wantScss}}
+  "style": "./dist/{{kebabCase name}}.min.css",{{/if}}
   "exports": {
     ".": {
       "import": "./dist/{{kebabCase name}}.js",
@@ -23,8 +23,8 @@
     "./*": "./*"
   },
   "files": [
-    "dist/*",
-    "scss/*"
+    "dist/*"{{#if wantScss}},
+    "scss/*"{{/if}}
   ],
   "keywords": [
     "video.js",
@@ -34,8 +34,8 @@
     "pillarbox-plugin"{{/ifEq}}{{/ifEq}}
   ],
   "scripts": {
-    "build": "npm run build:lib && npm run build:css",
-    "build:css": "sass ./scss/{{kebabCase name}}.scss:dist/{{kebabCase name}}.min.css --style compressed --source-map --load-path node_modules",
+    "build": "npm run build:lib{{#if wantScss}} && npm run build:css{{/if}}",{{#if wantScss}}
+    "build:css": "sass ./scss/{{kebabCase name}}.scss:dist/{{kebabCase name}}.min.css --style compressed --source-map --load-path node_modules",{{/if}}
     "build:lib": "vite build --config vite.config.lib.js",
     "github:page": "vite build",
     "release:ci": "semantic-release",

--- a/scripts/test/create.spec.js
+++ b/scripts/test/create.spec.js
@@ -22,7 +22,7 @@ describe('Plop generator', () => {
   });
 
   it('should generate a pillarbox plugin successfully', async() => {
-    await create(  { platform: 'pillarbox', type: 'Plugin', wantLocalization: false, });
+    await create(  { platform: 'pillarbox', type: 'Plugin', wantLocalization: false, wantScss: true });
     const packageJsonPath = path.join(testDir, 'package.json');
 
     expect(fs.existsSync(packageJsonPath)).toBe(true);
@@ -44,7 +44,7 @@ describe('Plop generator', () => {
   });
 
   it('should generate a pillarbox component with localization successfully', async() => {
-    await create(  { platform: 'pillarbox', type: 'Component', wantLocalization: true, });
+    await create(  { platform: 'pillarbox', type: 'Component', wantLocalization: true, wantScss: true});
     const packageJsonPath = path.join(testDir, 'package.json');
 
     expect(fs.existsSync(packageJsonPath)).toBe(true);
@@ -65,8 +65,8 @@ describe('Plop generator', () => {
     }
   });
 
-  it('should generate a video.js button with localization successfully', async() => {
-    await create(  { platform: 'videojs', type: 'Button', wantLocalization: true, });
+  it('should generate a video.js component without css successfully', async() => {
+    await create(  { platform: 'videojs', type: 'Component', wantLocalization: true, wantScss: false });
     const packageJsonPath = path.join(testDir, 'package.json');
 
     expect(fs.existsSync(packageJsonPath)).toBe(true);


### PR DESCRIPTION
## Description

Add a new prompt in the component generator to allow opting out of SCSS when creating a new element.

When SCSS is disabled, the generated component will skip the SCSS-to-CSS compilation step, adjust the package configuration to avoid exporting any CSS file, and no SCSS file will be created by default.

## Changes Made

- Added a prompt to opt-out of the SCSS generation.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
