### PR TITLE
chore(create): generate umd build

### DIFF
--- a/packages/pillarbox-debug-panel/package.json
+++ b/packages/pillarbox-debug-panel/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/pillarbox-debug-panel#readme",
   "type": "module",
   "main": "dist/pillarbox-debug-panel.cjs",
+  "browser": "dist/pillarbox-debug-panel.umd.min.js",
   "module": "dist/pillarbox-debug-panel.js",
   "style": "./dist/pillarbox-debug-panel.min.css",
   "exports": {

--- a/packages/pillarbox-debug-panel/vite.config.umd.js
+++ b/packages/pillarbox-debug-panel/vite.config.umd.js
@@ -3,11 +3,10 @@ import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 
 /**
- * Vite's configuration for the lib build.
+ * Vite's configuration for the UMD build.
  *
  * Outputs:
- * - 'dist/pillarbox-debug-panel.js': ESModule version with sourcemaps.
- * - 'dist/pillarbox-debug-panel.cjs': CommonJS version with sourcemaps.
+ * - 'dist/pillarbox-debug-panel.umd.min.js': ESModule version with sourcemaps.
  */
 export default defineConfig({
   esbuild: false,
@@ -20,12 +19,14 @@ export default defineConfig({
       entry: 'src/pillarbox-debug-panel.js'
     },
     rollupOptions: {
-      external: ['video.js'],
       output: {
+        name: 'PillarboxDebugPanel',
+        entryFileNames: 'pillarbox-debug.umd.min.js',
         globals: {
-          'video.js': 'videojs'
-        }
+          videojs: 'videojs',
+        },
       },
+      external: ['video.js'],
       plugins: [
         babel({
           babelHelpers: 'bundled',

--- a/packages/pillarbox-playlist/package.json
+++ b/packages/pillarbox-playlist/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/pillarbox-playlist#readme",
   "type": "module",
   "main": "dist/pillarbox-playlist.cjs",
+  "browser": "dist/pillarbox-playlist.umd.min.js",
   "module": "dist/pillarbox-playlist.js",
   "style": "./dist/pillarbox-playlist.min.css",
   "exports": {
@@ -39,9 +40,11 @@
     "playlist"
   ],
   "scripts": {
-    "build": "npm run build:lib && npm run build:ui && npm run build:css",
+    "build": "npm run build:lib && npm run build:ui && npm run build:umd && npm run build:umd:ui && npm run build:css",
     "build:css": "sass ./scss/pillarbox-playlist.scss:dist/pillarbox-playlist.min.css --style compressed --source-map --load-path node_modules",
     "build:lib": "vite build --config vite.config.lib.js",
+    "build:umd": "vite build --config vite.config.umd.js",
+    "build:umd:ui": "vite build --config vite.config.umd.ui.js",
     "build:ui": "vite build --config vite.config.ui.js",
     "github:page": "vite build",
     "release:ci": "semantic-release",

--- a/packages/pillarbox-playlist/vite.config.ui.js
+++ b/packages/pillarbox-playlist/vite.config.ui.js
@@ -3,11 +3,11 @@ import babel from '@rollup/plugin-babel';
 import copy from 'rollup-plugin-copy';
 
 /**
- * Vite's configuration for the lib build.
+ * Vite's configuration for the ui build.
  *
  * Outputs:
- * - 'dist/pillarbox-playlist-ui.js': ESModule version with sourcemaps.
- * - 'dist/pillarbox-playlist-ui.cjs': CommonJS version with sourcemaps.
+ * - 'dist/ui/pillarbox-playlist-ui.js': ESModule version with sourcemaps.
+ * - 'dist/ui/pillarbox-playlist-ui.cjs': CommonJS version with sourcemaps.
  */
 export default defineConfig({
   esbuild: false,

--- a/packages/pillarbox-playlist/vite.config.umd.js
+++ b/packages/pillarbox-playlist/vite.config.umd.js
@@ -3,10 +3,10 @@ import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 
 /**
- * Vite's configuration for the UMD build.
+ * Vite's configuration for the umd build.
  *
  * Outputs:
- * - 'dist/pillarbox-debug-panel.umd.min.js': Universal Module Definition version.
+ * - 'dist/pillarbox-playlist.umd.min.js': Universal Module Definition version.
  */
 export default defineConfig({
   esbuild: false,
@@ -15,15 +15,15 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       formats: ['umd'],
-      name: 'PillarboxDebugPanel',
-      entry: 'src/pillarbox-debug-panel.js'
+      name: 'PillarboxPlaylist',
+      entry: 'src/pillarbox-playlist.js'
     },
     rollupOptions: {
       output: {
-        name: 'PillarboxDebugPanel',
-        entryFileNames: 'pillarbox-debug.umd.min.js',
+        name: 'PillarboxPlaylist',
+        entryFileNames: 'pillarbox-playlist.umd.min.js',
         globals: {
-          videojs: 'videojs',
+          videojs: 'videojs'
         },
       },
       external: ['video.js'],
@@ -34,6 +34,6 @@ export default defineConfig({
         }),
         terser()
       ]
-    }
-  }
+    },
+  },
 });

--- a/packages/pillarbox-playlist/vite.config.umd.ui.js
+++ b/packages/pillarbox-playlist/vite.config.umd.ui.js
@@ -3,27 +3,28 @@ import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 
 /**
- * Vite's configuration for the UMD build.
+ * Vite's configuration for the umd UI build.
  *
  * Outputs:
- * - 'dist/pillarbox-debug-panel.umd.min.js': Universal Module Definition version.
+ * - 'dist/ui/pillarbox-playlist-ui.umd.min.js': Universal Module Definition version.
  */
 export default defineConfig({
   esbuild: false,
   build: {
+    outDir: 'dist/ui',
     emptyOutDir: false,
     sourcemap: true,
     lib: {
       formats: ['umd'],
-      name: 'PillarboxDebugPanel',
-      entry: 'src/pillarbox-debug-panel.js'
+      name: 'PillarboxPlaylistUI',
+      entry: 'src/pillarbox-playlist-ui.js'
     },
     rollupOptions: {
       output: {
-        name: 'PillarboxDebugPanel',
-        entryFileNames: 'pillarbox-debug.umd.min.js',
+        name: 'PillarboxPlaylistUI',
+        entryFileNames: 'pillarbox-playlist-ui.umd.min.js',
         globals: {
-          videojs: 'videojs',
+          videojs: 'videojs'
         },
       },
       external: ['video.js'],
@@ -34,6 +35,6 @@ export default defineConfig({
         }),
         terser()
       ]
-    }
-  }
+    },
+  },
 });

--- a/packages/skip-button/package.json
+++ b/packages/skip-button/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/skip-button#readme",
   "type": "module",
   "main": "dist/skip-button.cjs",
+  "browser": "dist/skip-button.umd.min.js",
   "module": "dist/skip-button.js",
   "style": "./dist/skip-button.min.css",
   "exports": {
@@ -35,10 +36,10 @@
     "skip-button"
   ],
   "scripts": {
-    "build": "npm run build:lib && npm run build:css",
+    "build": "npm run build:lib && npm run build:umd && npm run build:css",
     "build:css": "sass ./scss/skip-button.scss:dist/skip-button.min.css --style compressed --source-map --load-path node_modules",
     "build:lib": "vite build --config vite.config.lib.js",
-    "build:ui": "vite build --config vite.config.ui.js",
+    "build:umd": "vite build --config vite.config.umd.js",
     "github:page": "vite build",
     "release:ci": "semantic-release",
     "start": " vite --port 4200 --open",

--- a/packages/skip-button/vite.config.umd.js
+++ b/packages/skip-button/vite.config.umd.js
@@ -3,10 +3,10 @@ import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 
 /**
- * Vite's configuration for the UMD build.
+ * Vite's configuration for the umd build.
  *
  * Outputs:
- * - 'dist/pillarbox-debug-panel.umd.min.js': Universal Module Definition version.
+ * - 'dist/skip-button.umd.min.js': Universal Module Definition version.
  */
 export default defineConfig({
   esbuild: false,
@@ -15,18 +15,18 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       formats: ['umd'],
-      name: 'PillarboxDebugPanel',
-      entry: 'src/pillarbox-debug-panel.js'
+      name: 'SkipButton',
+      entry: 'src/skip-button.js'
     },
     rollupOptions: {
       output: {
-        name: 'PillarboxDebugPanel',
-        entryFileNames: 'pillarbox-debug.umd.min.js',
+        name: 'SkipButton',
+        entryFileNames: 'skip-button.umd.min.js',
         globals: {
-          videojs: 'videojs',
+          pillarbox: 'pillarbox'
         },
       },
-      external: ['video.js'],
+      external: ['@srgssr/pillarbox-web'],
       plugins: [
         babel({
           babelHelpers: 'bundled',
@@ -34,6 +34,6 @@ export default defineConfig({
         }),
         terser()
       ]
-    }
-  }
+    },
+  },
 });

--- a/packages/user-preferences/vite.config.umd.js
+++ b/packages/user-preferences/vite.config.umd.js
@@ -1,4 +1,6 @@
 import { defineConfig } from 'vite';
+import babel from '@rollup/plugin-babel';
+import terser from '@rollup/plugin-terser';
 
 /**
  * Vite's configuration for the umd build.
@@ -7,6 +9,7 @@ import { defineConfig } from 'vite';
  * - 'dist/user-preferences.umd.min.js': Universal Module Definition version.
  */
 export default defineConfig({
+  esbuild: false,
   build: {
     emptyOutDir: false,
     sourcemap: true,
@@ -24,6 +27,13 @@ export default defineConfig({
         },
       },
       external: ['video.js'],
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          exclude: 'node_modules/**'
+        }),
+        terser()
+      ]
     },
   },
 });

--- a/scripts/template/package.json.hbs
+++ b/scripts/template/package.json.hbs
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/{{kebabCase name}}#readme",
   "type": "module",
   "main": "dist/{{kebabCase name}}.cjs",
+  "browser": "dist/{{kebabCase name}}.umd.min.js",
   "module": "dist/{{kebabCase name}}.js",{{#if wantScss}}
   "style": "./dist/{{kebabCase name}}.min.css",{{/if}}
   "exports": {
@@ -34,9 +35,10 @@
     "pillarbox-plugin"{{/ifEq}}{{/ifEq}}
   ],
   "scripts": {
-    "build": "npm run build:lib{{#if wantScss}} && npm run build:css{{/if}}",{{#if wantScss}}
+    "build": "npm run build:lib && npm run build:umd{{#if wantScss}} && npm run build:css{{/if}}",{{#if wantScss}}
     "build:css": "sass ./scss/{{kebabCase name}}.scss:dist/{{kebabCase name}}.min.css --style compressed --source-map --load-path node_modules",{{/if}}
     "build:lib": "vite build --config vite.config.lib.js",
+    "build:umd": "vite build --config vite.config.umd.js",
     "github:page": "vite build",
     "release:ci": "semantic-release",
     "start": " vite --port 4200 --open",

--- a/scripts/template/vite.config.umd.js.hbs
+++ b/scripts/template/vite.config.umd.js.hbs
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vite';
+import babel from '@rollup/plugin-babel';
+import terser from '@rollup/plugin-terser';
+
+/**
+ * Vite's configuration for the umd build.
+ *
+ * Outputs:
+ * - 'dist/{{kebabCase name}}.umd.min.js': Universal Module Definition version.
+ */
+export default defineConfig({
+  esbuild: false,
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    lib: {
+      formats: ['umd'],
+      name: '{{properCase name}}',
+      entry: 'src/{{kebabCase name}}.js'
+    },
+    rollupOptions: {
+      output: {
+        name: '{{properCase name}}',
+        entryFileNames: '{{kebabCase name}}.umd.min.js',
+        globals: {
+          {{platform}}: '{{platform}}',
+        },
+      },
+      external: ['{{importAlias}}'],
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          exclude: 'node_modules/**'
+        }),
+        terser()
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Description

New and old components can now be loaded via a CDN (e.g., jsDelivr) using a simple <script> tag, enabling easier integration in external projects.

This PR makes sure that all new an existing UMD builds use the common babel configuration to align the compatibility requirements to those of the pillarbox-web player.

## Changes Made

- Added UMD build generation for new components.
- `pillarbox-debug-panel`: add specific browser export property to the package.json.
- `user-preferences`: align browser compatibility with Bable for the UMD build.
- Add a UMD build for both the `pillarbox-playlist` plugin and the `skip-button` component. An additional `ui` specific 
  build has been added to the pillarox-playlist plugin since this plugin allows to integration without the visual component.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
