### PR TITLE
feat(big-replay-button): publish replay button

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
   <li><a href="packages/skip-button/index.html">skip-button</a></li>
   <li><a href="packages/pillarbox-debug-panel/index.html">pillarbox-debug-panel</a></li>
   <li><a href="packages/user-preferences/index.html">user-preferences</a></li>
+  <li><a href="packages/big-replay-button/index.html">big-replay-button</a></li>
 </ul>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,6 +4395,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@srgssr/big-replay-button": {
+      "resolved": "packages/big-replay-button",
+      "link": true
+    },
     "node_modules/@srgssr/pillarbox-debug-panel": {
       "resolved": "packages/pillarbox-debug-panel",
       "link": true
@@ -21419,6 +21423,17 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "packages/big-replay-button": {
+      "name": "@srgssr/big-replay-button",
+      "version": "0.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@srgssr/pillarbox-web": "^1.14.1"
+      },
+      "peerDependencies": {
+        "video.js": "^8.0.0"
       }
     },
     "packages/pillarbox-debug-panel": {

--- a/packages/big-replay-button/.babelrc
+++ b/packages/big-replay-button/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../../babel.config.json"
+}

--- a/packages/big-replay-button/.releaserc
+++ b/packages/big-replay-button/.releaserc
@@ -1,0 +1,111 @@
+{
+  "branches": ["main"],
+  "extends": "semantic-release-monorepo",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
+        },
+        "presetConfig": {
+          "types": [
+            {
+              "type": "breaking",
+              "section": "Breaking Changes ❗",
+              "hidden": false
+            },
+            {
+              "type": "feat",
+              "section": "New Features 🚀",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": "Enhancements and Bug Fixes 🐛",
+              "hidden": false
+            },
+            {
+              "type": "docs",
+              "section": "Docs 📖",
+              "hidden": false
+            },
+            {
+              "type": "style",
+              "section": "Styles 🎨",
+              "hidden": false
+            },
+            {
+              "type": "refactor",
+              "section": "Refactor 🔩",
+              "hidden": false
+            },
+            {
+              "type": "perf",
+              "section": "Performances ⚡️",
+              "hidden": false
+            },
+            {
+              "type": "test",
+              "section": "Tests ✅",
+              "hidden": false
+            },
+            {
+              "type": "ci",
+              "section": "CI 🔁",
+              "hidden": false
+            },
+            {
+              "type": "chore",
+              "section": "Chore 🧹",
+              "hidden": false
+            }
+          ]
+        },
+        "writerOpts": {
+          "groupBy": "type",
+          "commitGroupsSort": [
+            "breaking",
+            "feat",
+            "fix"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/npm",
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "package.json",
+          "package-lock.json",
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "dist/**/*"
+          }
+        ]
+      }
+    ]
+  ]
+}
+

--- a/packages/big-replay-button/LICENSE
+++ b/packages/big-replay-button/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SRG SSR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/big-replay-button/README.md
+++ b/packages/big-replay-button/README.md
@@ -1,0 +1,75 @@
+# Pillarbox Web: Big-Replay-Button
+
+A big replay button that appears when the media ends, allowing users to easily restart playback.
+It integrates naturally with video.js, reusing the look and behavior of the standard big play
+button, and ensuring accessibility support.
+
+## Requirements
+
+To use this component, you need the following installed on your system:
+
+- Node.js
+
+## Quick Start
+
+To get started with this component, install it through the following command:
+
+```bash
+npm install --save video.js @srgssr/big-replay-button
+```
+
+Once the player is installed you can activate the component as follows:
+
+```javascript
+import videojs from 'video.js';
+import '@srgssr/big-replay-button';
+
+const player = videojs('my-player', { BigReplayButton: true });
+```
+
+To apply the default styling, add the following line to your CSS file:
+
+```css
+@import "@srgssr/big-replay-button/dist/big-replay-button.min.css";
+```
+
+## Contributing
+
+For detailed contribution guidelines, refer to our [Contributing guide][contributing-guide].
+Please adhere to the specified guidelines.
+
+### Setting up a development server
+
+Start the development server:
+
+```bash
+npm run start
+```
+
+This will start the server on `http://localhost:4200`. Open this URL in your browser to view the
+demo page.
+
+The video player (`player`) and the Pillarbox library (`pillarbox`) are exposed on the `window`
+object, making it easy to access and manipulate from the browser's developer console for debugging.
+
+#### Available URL parameters
+
+The demo page supports several URL parameters that modify the behavior of the video player:
+
+- `debug`: Set this to enable debugging mode.
+- `ilHost`: Specifies the host for the data provider.
+- `language`: Sets the language for the player interface.
+- `urn`: Specifies the URN of the video to load. Default is `urn:rts:video:14683290`.
+
+You can combine parameters in the URL like so:
+
+```plaintext
+http://localhost:4200/?language=fr&urn=urn:rts:video:14318206
+```
+
+## Licensing
+
+This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more
+details.
+
+[contributing-guide]: https://github.com/SRGSSR/pillarbox-web-suite/blob/main/docs/README.md#contributing

--- a/packages/big-replay-button/index.html
+++ b/packages/big-replay-button/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Big-Replay-Button Demo</title>
+  <style>
+    html,
+    body {
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+<video id="player" class="pillarbox-js" controls muted></video>
+
+<script type="module">
+  import '@srgssr/pillarbox-web/dist/pillarbox.min.css';
+  import pillarbox from '@srgssr/pillarbox-web';
+  import './scss/big-replay-button.scss';
+  import './src/big-replay-button.js';
+
+  // Handle URL parameters
+  const searchParams = new URLSearchParams(location.search);
+  const debug = searchParams.has('debug');
+  const ilHost = searchParams.get('ilHost') || undefined;
+  const language = searchParams.get('language');
+  const urn = searchParams.get('urn') || 'urn:rts:video:14683290';
+
+  // Create a pillarbox player instance with the BigReplayButton enabled
+  window.player = pillarbox('player', {
+    debug,
+    language,
+    srgOptions: {
+      dataProviderHost: ilHost
+    },
+    bigReplayButton: true
+  });
+
+  // Load the video source for the player
+  player.src({
+    src: urn,
+    type: 'srgssr/urn',
+    disableTrackers: true
+  });
+
+  // Expose player for debugging
+  window.player = player;
+  window.pillarbox = pillarbox;
+</script>
+</body>
+</html>

--- a/packages/big-replay-button/package.json
+++ b/packages/big-replay-button/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@srgssr/big-replay-button",
+  "version": "0.0.1",
+  "license": "MIT",
+  "author": "SRG SSR",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SRGSSR/pillarbox-web-suite.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/big-replay-button#readme",
+  "type": "module",
+  "main": "dist/big-replay-button.cjs",
+  "browser": "dist/big-replay-button.umd.min.js",
+  "module": "dist/big-replay-button.js",
+  "style": "./dist/big-replay-button.min.css",
+  "exports": {
+    ".": {
+      "import": "./dist/big-replay-button.js",
+      "require": "./dist/big-replay-button.cjs"
+    },
+    "./*": "./*"
+  },
+  "files": [
+    "dist/*",
+    "scss/*"
+  ],
+  "keywords": [
+    "video.js",
+    "player"
+  ],
+  "scripts": {
+    "build": "npm run build:lib && npm run build:umd && npm run build:css",
+    "build:css": "sass ./scss/big-replay-button.scss:dist/big-replay-button.min.css --style compressed --source-map --load-path node_modules",
+    "build:lib": "vite build --config vite.config.lib.js",
+    "build:umd": "vite build --config vite.config.umd.js",
+    "github:page": "vite build",
+    "release:ci": "semantic-release",
+    "start": " vite --port 4200 --open",
+    "test": "vitest run --silent --coverage --coverage.reporter text"
+  },
+  "peerDependencies": {
+    "video.js": "^8.0.0"
+  },
+  "devDependencies": {
+    "@srgssr/pillarbox-web": "^1.14.1"
+  }
+}

--- a/packages/big-replay-button/scss/big-replay-button.scss
+++ b/packages/big-replay-button/scss/big-replay-button.scss
@@ -1,0 +1,12 @@
+.vjs-has-started .pbw-big-replay-button,
+.vjs-paused .pbw-big-replay-button {
+  display: none;
+}
+
+.vjs-ended .pbw-big-replay-button {
+  display: block;
+
+  & .vjs-icon-placeholder:before {
+    content: "\f11b";
+  }
+}

--- a/packages/big-replay-button/src/big-replay-button.js
+++ b/packages/big-replay-button/src/big-replay-button.js
@@ -1,0 +1,37 @@
+import videojs from 'video.js';
+import { version } from '../package.json';
+
+/**
+ * @ignore
+ * @type {typeof import('video.js/dist/types/button').default}
+ */
+const BigPlayButton = videojs.getComponent('BigPlayButton');
+
+/**
+ * Represents a BigReplayButton component for the videojs player.
+ */
+class BigReplayButton extends BigPlayButton {
+  /**
+   * Creates an instance of a BigReplayButton.
+   *
+   * @param {import('video.js/dist/types/player.js').default} player The player instance.
+   * @param {Object} options Configuration options for the component.
+   */
+  constructor(player, options) {
+    super(player, options);
+    this.controlText('Replay');
+    this.setIcon('replay');
+  }
+
+  buildCSSClass() {
+    return `${super.buildCSSClass()} pbw-big-replay-button`;
+  }
+
+  static get VERSION() {
+    return version;
+  }
+}
+
+videojs.registerComponent('BigReplayButton', BigReplayButton);
+
+export default BigReplayButton;

--- a/packages/big-replay-button/test/big-replay-button.spec.js
+++ b/packages/big-replay-button/test/big-replay-button.spec.js
@@ -1,0 +1,40 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import videojs from 'video.js';
+import BigReplayButton from '../src/big-replay-button.js';
+
+window.HTMLMediaElement.prototype.load = () => {};
+
+describe('BigReplayButton', () => {
+  let player, videoElement;
+
+  beforeAll(() => {
+    document.body.innerHTML = '<video id="test-video" class="video-js"></video>';
+    videoElement = document.querySelector('#test-video');
+  });
+
+  beforeEach(() => {
+    player = videojs(videoElement, { BigReplayButton: true });
+  });
+
+  afterEach(() => {
+    player.dispose();
+    vi.resetAllMocks();
+  });
+
+  it('should be registered and attached to the player', () => {
+    expect(videojs.getComponent('BigReplayButton')).toBe(BigReplayButton);
+    expect(player.BigReplayButton).toBeDefined();
+    expect(BigReplayButton.VERSION).toBeDefined();
+  });
+
+  it('should restart the video when clicked', () => {
+    const buttonInstance = player.getChild('BigReplayButton');
+    const playSpy = vi.spyOn(player, 'play');
+
+    // When
+    buttonInstance.trigger('click');
+
+    // Then
+    expect(playSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/big-replay-button/vite.config.js
+++ b/packages/big-replay-button/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './',
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/packages/big-replay-button/vite.config.lib.js
+++ b/packages/big-replay-button/vite.config.lib.js
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vite';
+import babel from '@rollup/plugin-babel';
+
+/**
+ * Vite's configuration for the lib build.
+ *
+ * Outputs:
+ * - 'dist/big-replay-button.js': ESModule version with sourcemaps.
+ * - 'dist/big-replay-button.cjs': CommonJS version with sourcemaps.
+ */
+export default defineConfig({
+  esbuild: false,
+  build: {
+    sourcemap: true,
+    lib: {
+      formats: ['es', 'cjs'],
+      name: 'BigReplayButton',
+      entry: 'src/big-replay-button.js'
+    },
+    rollupOptions: {
+      external: ['video.js'],
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          exclude: 'node_modules/**'
+        })
+      ]
+    }
+  }
+});

--- a/packages/big-replay-button/vite.config.umd.js
+++ b/packages/big-replay-button/vite.config.umd.js
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vite';
+import babel from '@rollup/plugin-babel';
+import terser from '@rollup/plugin-terser';
+
+/**
+ * Vite's configuration for the umd build.
+ *
+ * Outputs:
+ * - 'dist/big-replay-button.umd.min.js': Universal Module Definition version.
+ */
+export default defineConfig({
+  esbuild: false,
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    lib: {
+      formats: ['umd'],
+      name: 'BigReplayButton',
+      entry: 'src/big-replay-button.js'
+    },
+    rollupOptions: {
+      output: {
+        name: 'BigReplayButton',
+        entryFileNames: 'big-replay-button.umd.min.js',
+        globals: {
+          videojs: 'videojs',
+        },
+      },
+      external: ['video.js'],
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          exclude: 'node_modules/**'
+        }),
+        terser()
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Description

Resolves #38 by introducing a `BigReplayButton` component for the video.js player.

This component extends the existing BigPlayButton and is displayed only when the video has ended. With this approach we maintain accessibility standards and minimize the need for additional styling from integrators.

Key features:

- Displays a replay button when the video ends.
- Hides the button during playback or pause states.
- Allows styling reuse for projects already using the BigPlayButton.
- Sets the control text to "Replay" and the icon to a replay symbol.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
