### PR TITLE
fix(thumbnail-preview): remove braces from listeners

### DIFF
--- a/packages/thumbnail-preview/src/components/thumbnail-preview-overlay.js
+++ b/packages/thumbnail-preview/src/components/thumbnail-preview-overlay.js
@@ -129,8 +129,8 @@ class ThumbnailPreviewOverlay extends Component {
 
     const progressControl = this.getProgressControl();
 
-    progressControl.on(['pointermove'], this.#onMove);
-    progressControl.on(['pointerleave'], this.#onCancel);
+    progressControl.on('pointermove', this.#onMove);
+    progressControl.on('pointerleave', this.#onCancel);
     this.player().on('userinactive', this.#onCancel);
     this.player().on('playerresize', this.#onPlayerResize);
 
@@ -147,8 +147,8 @@ class ThumbnailPreviewOverlay extends Component {
 
     const progressControl = this.getProgressControl();
 
-    progressControl.off(['pointermove'], this.#onMove);
-    progressControl.off(['pointerleave'], this.#onCancel);
+    progressControl.off('pointermove', this.#onMove);
+    progressControl.off('pointerleave', this.#onCancel);
     this.player().off('userinactive', this.#onCancel);
     this.player().off('playerresize', this.#onPlayerResize);
 


### PR DESCRIPTION
## Description

Remove braces from pointer event listeners, only one event is listened to.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
