### PR TITLE
fix(thumbnail-preview): avoid crash when sprite is undefined

### DIFF
--- a/packages/thumbnail-preview/src/components/thumbnail-preview-overlay.js
+++ b/packages/thumbnail-preview/src/components/thumbnail-preview-overlay.js
@@ -84,7 +84,9 @@ class ThumbnailPreviewOverlay extends Component {
    * resizes the thumbnail holder to match the expected layout.
    */
   init() {
-    if (this.options().sprite.url) {
+    const { sprite } = this.options();
+
+    if (sprite && sprite.url) {
       this.initListeners();
       this.resizeThumbnail();
       this.thumbnail.src = this.options().sprite.url;

--- a/packages/thumbnail-preview/test/thumbnail-preview.spec.js
+++ b/packages/thumbnail-preview/test/thumbnail-preview.spec.js
@@ -196,6 +196,31 @@ describe('ThumbnailPreview', () => {
       expect(thumbnailPreviewOverlay.active).toBeFalsy();
     });
 
+    it('should deactivate the thumbnail when updateSprite is called with an undefined sprite', () => {
+      const progressControl = player.controlBar.progressControl;
+      const thumbnailPreviewOverlay = progressControl.thumbnailPreviewOverlay;
+      const overlayEl = thumbnailPreviewOverlay.el();
+
+      expect(overlayEl.classList).not.toContain(`vjs-hidden`);
+      expect(thumbnailPreviewOverlay.active).toBeTruthy();
+      player.thumbnailPreview().updateSprite(undefined);
+      expect(overlayEl.classList).toContain('vjs-hidden');
+      expect(thumbnailPreviewOverlay.active).toBeFalsy();
+    });
+
+
+    it('should deactivate the thumbnail when passing a sprite without url', () => {
+      const progressControl = player.controlBar.progressControl;
+      const thumbnailPreviewOverlay = progressControl.thumbnailPreviewOverlay;
+      const overlayEl = thumbnailPreviewOverlay.el();
+
+      expect(overlayEl.classList).not.toContain(`vjs-hidden`);
+      expect(thumbnailPreviewOverlay.active).toBeTruthy();
+      player.thumbnailPreview().updateSprite({ url: undefined });
+      expect(overlayEl.classList).toContain('vjs-hidden');
+      expect(thumbnailPreviewOverlay.active).toBeFalsy();
+    });
+
   });
 
   describe('when progress control is missing', () => {


### PR DESCRIPTION
## Description

Guarded access to `sprite` in `init()` to prevent `TypeError` when `updateSprite(undefined)` is called.

This ensures `resetSprite()` is invoked if `sprite` or `sprite.url` is missing, avoiding runtime errors and making `updateSprite()` more robust against invalid input.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
