### PR TITLE
feat(cast): add customizable Google Cast button and native launcher

### DIFF
--- a/packages/google-cast-sender/README.md
+++ b/packages/google-cast-sender/README.md
@@ -1,6 +1,9 @@
 # Pillarbox Web: GoogleCastSender
 
-This plugin integrates Google Cast functionality into a video.js player, allowing users to stream video content to a Chromecast device. It supports subtitle and audio track selection. It also allows for custom source resolution, which is useful for integrations that play custom sources based on IDs or other middleware logic. Finally it also supports live streams with DVR capabilities.
+This plugin integrates Google Cast functionality into a video.js player, allowing users to stream
+video content to a Chromecast device. It supports subtitle and audio track selection. It also allows
+for custom source resolution, which is useful for integrations that play custom sources based on IDs
+or other middleware logic. Finally it also supports live streams with DVR capabilities.
 
 ## Requirements
 
@@ -21,6 +24,7 @@ Once the player is installed you can activate the plugin as follows:
 ```javascript
 import videojs from 'video.js';
 import '@srgssr/google-cast-sender';
+import '@srgssr/google-cast-sender/launcher';
 
 const player = videojs('player', {
   techOrder: ['chromecast', 'html5'],
@@ -40,16 +44,16 @@ To apply the default styling, add the following line to your CSS file:
 
 ### Options
 
-The component's behavior can be customized by passing options during player initialization under the `googleCastSender` key:
+The component's behavior can be customized by passing options during player initialization under the
+`googleCastSender` key:
 
-| Option                    | Type     | Default                                                                      | Description                                                                                                                                                             |
-|---------------------------|----------|------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `androidReceiverCompatible` | `boolean`  | `true`                                                                       | Indicates whether the receiver application is compatible with Android TV devices.                                                                                       |
-| `autoJoinPolicy`          | `string`   | `chrome.cast.AutoJoinPolicy.TAB_AND_ORIGIN_SCOPED`                           | The policy for automatically joining a Cast session. See [AutoJoinPolicy docs](https://developers.google.com/cast/docs/reference/web_sender/chrome.cast#.AutoJoinPolicy). |
-| `enableDefaultCastButton` | `boolean`  | `true`                                                                       | Indicates whether the default Cast button should be displayed in the controlBar.                                                                                        |
-| `receiverApplicationId`   | `string`   | `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID`                            | The ID of the receiver application to use. The default receiver does not handle DRM content.                                                                            |
-| `script`                  | `object`   | `{ id: 'gstatic_cast_sender', src: '...' }`                                  | Configuration for the Google Cast sender script.                                                                                                                        |
-| `sourceResolver`          | `function` | `undefined`                                                                  | A function to resolve the source to be played on the cast device.                                                                                                       |
+| Option                      | Type       | Default                                            | Description                                                                                                                                                               |
+|-----------------------------|------------|----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `androidReceiverCompatible` | `boolean`  | `true`                                             | Indicates whether the receiver application is compatible with Android TV devices.                                                                                         |
+| `autoJoinPolicy`            | `string`   | `chrome.cast.AutoJoinPolicy.TAB_AND_ORIGIN_SCOPED` | The policy for automatically joining a Cast session. See [AutoJoinPolicy docs](https://developers.google.com/cast/docs/reference/web_sender/chrome.cast#.AutoJoinPolicy). |
+| `receiverApplicationId`     | `string`   | `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID`  | The ID of the receiver application to use. The default receiver does not handle DRM content.                                                                              |
+| `script`                    | `object`   | `{ id: 'gstatic_cast_sender', src: '...' }`        | Configuration for the Google Cast sender script.                                                                                                                          |
+| `sourceResolver`            | `function` | `undefined`                                        | A function to resolve the source to be played on the cast device.                                                                                                         |
 
 **Example:**
 
@@ -61,12 +65,78 @@ const player = new videojs('my-player', {
       receiverApplicationId: 'YOUR_APP_ID',
       sourceResolver: (source) => {
         // modify the source for the cast device
-        return { ...source, src: source.src.replace('example.com', 'cast.example.com') };
+        return {
+          ...source,
+          src: source.src.replace('example.com', 'cast.example.com')
+        };
       }
     }
   }
 });
 ```
+
+### User Interface
+
+The plugin provides two ways to integrate a Cast button into your player. **Both are automatically
+added to the Video.js control bar once you import them.**
+
+#### 1. Chromecast Launcher (default)
+
+```js
+import "@srgssr/google-cast-sender/launcher";
+```
+
+This is the standard Google Cast launcher wrapped as a Video.js component. It is **plug-and-play**
+and automatically manages Cast sessions.
+
+* **Pros**: Zero configuration required.
+* **Cons**: Limited customization and not fully accessible.
+
+#### 2. Chromecast Button (customizable)
+
+```js
+import "@srgssr/google-cast-sender/button";
+```
+
+This is a custom button built on top of the extends the shared [`SvgButton`][svg-button-api]
+component. All `SvgButton`options are supported.
+
+| Option     | Type                          | Default     | Description                                                                                                                           |
+|------------|-------------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `icon`     | `SVGElement \| string \| URL` | `undefined` | An SVG icon to display inside the button. Can be an SVGElement, a raw SVG string, or a URL (string or URL object). Throws if invalid. |
+| `iconName` | `string`                      | `'airplay'` | Used when SVG icon class integration is enabled (e.g., `vjs-icon-airplay`).                                                           |                                         
+
+Example:
+
+  ```js
+  import icon from './cast-icon.svg?raw';
+
+const player = videojs('player', {
+  controlBar: {
+    googleCastButton: { icon }
+  }
+});
+  ```
+
+#### Placement & Removal
+
+Since both components are automatically injected into the control bar, you only need to modify
+placement if you want to customize their order or remove them:
+
+* **Disable via options**:
+
+  ```js
+  const player = videojs('player', {
+    controlBar: {
+      googleCastButton: false,
+      googleCastLauncher: false
+    }
+  });
+  ```
+* **Reorder manually**: update the `controlBar.children` array with your desired button order.
+
+The default styles are included in the plugin’s CSS, and both buttons can be themed or replaced with
+custom icons as needed.
 
 ## Contributing
 
@@ -104,9 +174,8 @@ http://localhost:4200/?language=fr&urn=urn:rts:video:14318206
 
 ## Known issues
 
-- chromecast default button accessibility properties
-- live stream resume playback on local player
-
+- Chromecast default button accessibility properties
+- Live stream resume playback on local player
 
 ## Licensing
 
@@ -114,3 +183,4 @@ This project is licensed under the MIT License. See the [LICENSE](./LICENSE) fil
 details.
 
 [contributing-guide]: https://github.com/SRGSSR/pillarbox-web-suite/blob/main/docs/README.md#contributing
+[svg-button-api]: ../svg-button/README.md#api-documentation

--- a/packages/google-cast-sender/assets/google-cast.svg
+++ b/packages/google-cast-sender/assets/google-cast.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M0 0h24v24H0z' fill='none'/>
+  <path d='M0 0h24v24H0z' fill='none' opacity='.1'/>
+  <path
+    d='M1 18v3h3c0-1.66-1.34-3-3-3zm0-4v2c2.76 0 5 2.24 5 5h2c0-3.87-3.13-7-7-7zm18-7H5v1.63c3.96 1.28 7.09 4.41 8.37 8.37H19V7zM1 10v2c4.97 0 9 4.03 9 9h2c0-6.08-4.93-11-11-11zm20-7H3c-1.1 0-2 .9-2 2v3h2V5h18v14h-7v2h7c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z'/>
+</svg>

--- a/packages/google-cast-sender/index.html
+++ b/packages/google-cast-sender/index.html
@@ -27,6 +27,7 @@
       import pillarbox from "@srgssr/pillarbox-web";
       import "./scss/google-cast-sender.scss";
       import "./src/google-cast-sender.js";
+      import "./src/components/google-cast-button.js";
 
       // Handle URL parameters
       const searchParams = new URLSearchParams(location.search);

--- a/packages/google-cast-sender/package.json
+++ b/packages/google-cast-sender/package.json
@@ -21,6 +21,14 @@
       "import": "./dist/google-cast-sender.js",
       "require": "./dist/google-cast-sender.cjs"
     },
+    "./button": {
+      "import": "./dist/ui/google-cast-button.js",
+      "require": "./dist/ui/google-cast-button.cjs"
+    },
+    "./launcher": {
+      "import": "./dist/ui/google-cast-launcher.js",
+      "require": "./dist/ui/google-cast-launcher.cjs"
+    },
     "./*": "./*"
   },
   "files": [
@@ -40,12 +48,21 @@
   "scripts": {
     "build": "npm run build:lib && npm run build:umd && npm run build:css",
     "build:css": "sass ./scss/google-cast-sender.scss:dist/google-cast-sender.min.css --style compressed --source-map --load-path node_modules",
-    "build:lib": "vite build --config vite.config.lib.js",
-    "build:umd": "vite build --config vite.config.umd.js",
+    "build:lib:sender": "BUILD_TARGET=sender vite build --config vite.config.lib.js",
+    "build:lib:button": "BUILD_TARGET=button vite build --config vite.config.lib.js",
+    "build:lib:launcher": "BUILD_TARGET=launcher vite build --config vite.config.lib.js",
+    "build:lib": "npm run build:lib:sender && npm run build:lib:button && npm run build:lib:launcher",
+    "build:umd:sender": "BUILD_TARGET=sender vite build --config vite.config.umd.js",
+    "build:umd:button": "BUILD_TARGET=button vite build --config vite.config.umd.js",
+    "build:umd:launcher": "BUILD_TARGET=launcher vite build --config vite.config.umd.js",
+    "build:umd": "npm run build:umd:sender && npm run build:umd:button && npm run build:umd:launcher",
     "github:page": "vite build",
     "release:ci": "semantic-release",
     "start": " vite --port 4200 --open",
     "test": "vitest run --silent --coverage --coverage.reporter text"
+  },
+  "dependencies": {
+    "@srgssr/svg-button": "^1.0.0"
   },
   "peerDependencies": {
     "video.js": "^8.0.0"

--- a/packages/google-cast-sender/scss/google-cast-sender.scss
+++ b/packages/google-cast-sender/scss/google-cast-sender.scss
@@ -1,15 +1,16 @@
-.vjs-chromecast-button.vjs-button {
+.vjs-google-cast-launcher.vjs-button {
   --connected-color: currentColor;
-  --disconnected-color:currentColor;
+  --disconnected-color: currentColor;
   padding: .55em;
+  cursor: pointer;
 }
 
 .vjs-tech-chromecast {
-    display: none;
-    background-color: #000;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
+  display: none;
+  background-color: #000;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
 }
 
 .vjs-tech-chromecast-container {
@@ -45,4 +46,8 @@
   .vjs-picture-in-picture-control {
     display: none;
   }
+}
+
+.vjs-google-cast-button {
+  cursor: pointer;
 }

--- a/packages/google-cast-sender/src/components/google-cast-button.js
+++ b/packages/google-cast-sender/src/components/google-cast-button.js
@@ -1,0 +1,95 @@
+import videojs from 'video.js';
+import '@srgssr/svg-button';
+import googleCastIcon from '../../assets/google-cast.svg?raw';
+import { version } from '../../package.json';
+
+/**
+ * @ignore
+ * @type {typeof import('video.js').Component}
+ */
+const SvgButton = videojs.getComponent('SvgButton');
+
+/**
+ * @ignore
+ * @type {typeof import('video.js/dist/types/utils/log.js').default}
+ */
+const log = videojs.log.createLogger('google-cast-button');
+
+/**
+ * A custom Google Cast button for the Video.js player.
+ *
+ * Unlike the default Google Cast launcher, this button is based on
+ * {@link SvgButton} and therefore supports customization of its
+ * icon and appearance.
+ *
+ * By default, clicking the button will request a new Cast session
+ * using the Google Cast SDK.
+ */
+class GoogleCastButton extends SvgButton {
+
+  /**
+   * Creates an instance of GoogleCastButton.
+   *
+   * @param {import('video.js/dist/types/player.js').default} player
+   *        The Video.js player instance.
+   *
+   * @param {Object} [options={}]
+   *        Configuration options for the button. Supports all options
+   *        from {@link SvgButton}, such as `icon`, `iconName`, and `controlText`.
+   */
+  constructor(player, options = {}) {
+    super(player, options);
+
+    if (!window.chrome) {
+      this.hide();
+    }
+
+    if (!player.usingPlugin('googleCastSender')) {
+      log.error('The google-cast-sender plugin is required');
+    }
+  }
+
+  /**
+   * Handles click events on the Google Cast button.
+   * Requests a Cast session from the Google Cast SDK.
+   *
+   * @param {Event} event The click event.
+   */
+  handleClick(event) {
+    super.handleClick(event);
+    window.cast.framework.CastContext.getInstance().requestSession();
+  }
+
+  /**
+   * Builds the CSS class string for the button.
+   *
+   * @returns {string} The CSS class string.
+   */
+  buildCSSClass() {
+    return `vjs-google-cast-button ${super.buildCSSClass()}`;
+  }
+
+  /**
+   * Returns the current version of the GoogleCastButton component.
+   *
+   * @static
+   * @returns {string} The version string.
+   */
+  static get VERSION() {
+    return version;
+  }
+}
+
+GoogleCastButton.prototype.options_ = {
+  iconName: 'google-cast',
+  icon: googleCastIcon,
+  controlText: 'Use Google Cast'
+};
+
+videojs.registerComponent('GoogleCastButton', GoogleCastButton);
+
+const controlBarChildren = videojs.getComponent('ControlBar').prototype.options_.children;
+
+controlBarChildren.splice(controlBarChildren.length - 1, 0, 'GoogleCastButton');
+
+export default GoogleCastButton;

--- a/packages/google-cast-sender/src/components/google-cast-launcher.js
+++ b/packages/google-cast-sender/src/components/google-cast-launcher.js
@@ -1,0 +1,116 @@
+import videojs from 'video.js';
+import { version } from '../../package.json';
+
+/**
+ * @ignore
+ * @type {typeof import('video.js').Component}
+ */
+const Component = videojs.getComponent('Component');
+
+/**
+ * @ignore
+ * @type {typeof import('video.js/dist/types/utils/log.js').default}
+ */
+const log = videojs.log.createLogger('google-cast-launcher');
+
+/**
+ * A Google Cast launcher component for the Video.js player.
+ *
+ * This wraps the native `<google-cast-launcher>` element provided by
+ * the Google Cast SDK. It automatically manages session handling,
+ * but offers limited customization compared to {@link GoogleCastButton}.
+ */
+class GoogleCastLauncher extends Component {
+
+  /**
+   * Creates an instance of GoogleCastLauncher.
+   *
+   * @param {import('video.js/dist/types/player.js').default} player
+   *        The Video.js player instance.
+   *
+   * @param {Object} [options={}]
+   *        Configuration options for the launcher. Supports:
+   *        - `title` {string} Accessible title for the button (default: `"Use Google Cast"`).
+   */
+  constructor(player, options = {}) {
+    super(player, options);
+
+    if (!window.chrome) {
+      this.hide();
+    }
+
+    if (!player.usingPlugin('googleCastSender')) {
+      log.error('The google-cast-sender plugin is required');
+    }
+  }
+
+  /**
+   * Constructs the DOM element that will be used to render the launcher.
+   * Ensures the element is a `<google-cast-launcher>` and applies
+   * proper attributes and CSS classes.
+   *
+   * @param {string} [tag='google-cast-launcher']
+   *        The HTML tag name. Must be `'google-cast-launcher'`.
+   *
+   * @param {Object} [props={}]
+   *        Additional properties to apply to the element.
+   *
+   * @param {Object} [attributes={}]
+   *        Additional attributes to set on the element.
+   *
+   * @returns {HTMLElement}
+   *          The created `<google-cast-launcher>` element.
+   */
+  createEl(tag = 'google-cast-launcher', props = {}, attributes = {}) {
+    if (tag !== 'google-cast-launcher') {
+      log.error(`Creating a GoogleCastLauncher with an HTML element of ${tag} is not supported; the element must be an 'google-cast-launcher'`);
+      throw new Error(`'${tag}' is not supported for GoogleCastLauncher`);
+    }
+
+    const { title } = this.options();
+
+    return super.createEl(
+      tag,
+      videojs.obj.merge({ className: this.buildCSSClass() }, props),
+      videojs.obj.merge({ title: this.localize(title), }, attributes)
+    );
+  }
+
+  /**
+   * Builds the CSS class string for the launcher.
+   *
+   * @returns {string} The CSS class string.
+   */
+  buildCSSClass() {
+    return `vjs-google-cast-launcher vjs-control vjs-button ${super.buildCSSClass()}`;
+  }
+
+  /**
+   * Updates the launcher title when the player's language changes.
+   */
+  handleLanguagechange() {
+    this.el().title = this.localize(this.options().title);
+  }
+
+  /**
+   * Returns the current version of the GoogleCastLauncher component.
+   *
+   * @static
+   * @returns {string} The version string.
+   */
+  static get VERSION() {
+    return version;
+  }
+}
+
+GoogleCastLauncher.prototype.options_ = {
+  title: 'Use Google Cast'
+};
+
+videojs.registerComponent('GoogleCastLauncher', GoogleCastLauncher);
+
+const controlBarChildren = videojs.getComponent('ControlBar').prototype.options_.children;
+
+controlBarChildren.splice(controlBarChildren.length - 1, 0, 'GoogleCastLauncher');
+
+export default GoogleCastLauncher;

--- a/packages/google-cast-sender/src/google-cast-sender.js
+++ b/packages/google-cast-sender/src/google-cast-sender.js
@@ -26,8 +26,6 @@ const log = videojs.log.createLogger('GoogleCastSender-plugin');
  *           receiver application is compatible with Android TV devices
  * @property {string} [autoJoinPolicy=chrome.cast.AutoJoinPolicy.TAB_AND_ORIGIN_SCOPED] the policy for
  *           automatically joining a Cast session
- * @property {boolean} [enableDefaultCastButton=true] indicates whether the
- *           default Cast button should be displayed in the controlBar
  * @property {string} [receiverApplicationId=chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID] the ID of the receiver application to use.
  *           Note that the default receiver doesn't handle DRM content.
  * @property {object} [script] configuration for the Google Cast sender script
@@ -52,7 +50,6 @@ const Plugin = videojs.getPlugin('plugin');
  * @see [AutoJoinPolicy](https://developers.google.com/cast/docs/reference/web_sender/chrome.cast#.AutoJoinPolicy)
  * @see [CastOptions](https://developers.google.com/cast/docs/reference/web_sender/cast.framework.CastOptions)
  * @see [SessionState](https://developers.google.com/cast/docs/reference/web_sender/cast.framework#.SessionState)
- * @see [Default cast button](https://developers.google.com/cast/docs/web_sender/integrate#cast_button)
  *
  * @extends Plugin
  */
@@ -66,7 +63,6 @@ class GoogleCastSender extends Plugin {
   #options = {
     androidReceiverCompatible: true,
     autoJoinPolicy: 'tab_and_origin_scoped',
-    enableDefaultCastButton: true, // https://developers.google.com/cast/docs/web_sender/integrate#cast_button
     receiverApplicationId: undefined,
     script: {
       id: 'gstatic_cast_sender',
@@ -105,46 +101,6 @@ class GoogleCastSender extends Plugin {
     if (typeof this.#options.sourceResolver !== 'function') return source;
 
     return this.#options.sourceResolver(source);
-  }
-
-  /**
-   * Creates the Google Cast button and adds it to the player's control bar.
-   *
-   * The button is only added after the Google Cast API is available.
-   *
-   * https://developers.google.com/cast/docs/web_sender/integrate#cast_button
-   *
-   * @private
-   */
-  enableDefaultCastButton() {
-    if (
-      !this.#options.enableDefaultCastButton ||
-      !this.player.controlBar
-    ) return;
-
-    const castButton = document.createElement('google-cast-launcher');
-
-    castButton.classList.add(
-      'vjs-chromecast-button',
-      'vjs-control',
-      'vjs-button'
-    );
-
-    const controlBarChildren = this.player.controlBar.children();
-
-    controlBarChildren[controlBarChildren.length - 1].el().before(castButton);
-  }
-  /**
-   * Removes the Google Cast button.
-   *
-   * @private
-   */
-  removeDefaultCastButton() {
-    const castButton = videojs.dom.$('google-cast-launcher');
-
-    if (!castButton) return;
-
-    castButton.remove();
   }
 
   /**
@@ -307,7 +263,6 @@ class GoogleCastSender extends Plugin {
    *
    * It will:
    * - initialize the CastContext
-   * - add the default cast button if the option is set to true
    * - setup the SESSION_STATE_CHANGED listener
    *
    * @param {boolean} isAvailable whether the API is available
@@ -327,8 +282,6 @@ class GoogleCastSender extends Plugin {
 
     this.#castContext = cast.framework.CastContext.getInstance();
     this.#castContext.setOptions(castOptions);
-
-    this.enableDefaultCastButton();
 
     this.#castContext.addEventListener(
       cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
@@ -377,7 +330,6 @@ class GoogleCastSender extends Plugin {
   dispose() {
     this.removeCastListener();
     this.removeCastScript();
-    this.removeDefaultCastButton();
     this.endCurrentSession();
 
     delete window.__onGCastApiAvailable;

--- a/packages/google-cast-sender/src/lang/de.json
+++ b/packages/google-cast-sender/src/lang/de.json
@@ -1,3 +1,4 @@
 {
-  "Playing on {1}": "Wiedergabe auf {1}"
+  "Playing on {1}": "Wiedergabe auf {1}",
+  "Use Google Cast": "Google Cast verwenden"
 }

--- a/packages/google-cast-sender/src/lang/en.json
+++ b/packages/google-cast-sender/src/lang/en.json
@@ -1,3 +1,4 @@
 {
-  "Playing on {1}": "Playing on {1}"
+  "Playing on {1}": "Playing on {1}",
+  "Use Google Cast": "Utiliser Google Cast"
 }

--- a/packages/google-cast-sender/src/lang/fr.json
+++ b/packages/google-cast-sender/src/lang/fr.json
@@ -1,3 +1,4 @@
 {
-  "Playing on {1}": "Lecture en cours sur {1}"
+  "Playing on {1}": "Lecture en cours sur {1}",
+  "Use Google Cast": "Utiliser Google Cast"
 }

--- a/packages/google-cast-sender/src/lang/it.json
+++ b/packages/google-cast-sender/src/lang/it.json
@@ -1,3 +1,4 @@
 {
-  "Playing on {1}": "In riproduzione su {1}"
+  "Playing on {1}": "In riproduzione su {1}",
+  "Use Google Cast": "Usa Google Cast"
 }

--- a/packages/google-cast-sender/src/lang/rm.json
+++ b/packages/google-cast-sender/src/lang/rm.json
@@ -1,3 +1,4 @@
 {
-  "Playing on {1}": "Reda sin via {1}"
+  "Playing on {1}": "Reda sin via {1}",
+  "Use Google Cast": "Utilisar Google Cast"
 }

--- a/packages/google-cast-sender/test/components/google-cast-button.spec.js
+++ b/packages/google-cast-sender/test/components/google-cast-button.spec.js
@@ -1,0 +1,89 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import videojs from 'video.js';
+import '../../src/google-cast-sender.js';
+import GoogleCastButton from '../../src/components/google-cast-button.js';
+import '../google-cast.mock.js';
+
+window.HTMLMediaElement.prototype.load = () => { };
+
+describe('GoogleCastButton', () => {
+  let player, videoElement;
+
+  beforeAll(() => {
+    document.body.innerHTML = '<video id="test-video" class="video-js"></video>';
+    videoElement = document.querySelector('#test-video');
+  });
+
+  describe('Google Cast not supported', () => {
+    let chromeBackup;
+
+    beforeAll(() => {
+      chromeBackup = window.chrome;
+      window.chrome = undefined;
+    });
+
+    beforeEach(() => {
+      player = videojs(videoElement, {
+        techOrder: ['chromecast', 'html5'],
+        plugins: { googleCastSender: true }
+      });
+    });
+
+    afterEach(() => {
+      player.dispose();
+    });
+
+    afterAll(() => {
+      window.chrome = chromeBackup;
+    });
+
+    it('should be registered and attached to the player', () => {
+      expect(videojs.getComponent('GoogleCastButton')).toBe(GoogleCastButton);
+      expect(player.controlBar.GoogleCastButton).toBeDefined();
+      expect(GoogleCastButton.VERSION).toBeDefined();
+    });
+
+    it('should hide the button if chrome is not available', () => {
+      expect(player.controlBar.GoogleCastButton.hasClass('vjs-hidden')).toBeTruthy();
+    });
+  });
+
+  describe('Google Cast supported', () => {
+    let requestSessionSpy;
+
+    beforeEach(async() => {
+      player = videojs(videoElement, {
+        techOrder: ['chromecast', 'html5'],
+        plugins: { googleCastSender: true }
+      });
+
+      // grab requestSession spy
+      requestSessionSpy = vi.spyOn(
+        window.cast.framework.CastContext.getInstance(),
+        'requestSession'
+      );
+
+      await new Promise((resolve) => player.ready(resolve));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      player.dispose();
+    });
+
+    it('should be registered and attached to the player', () => {
+      expect(videojs.getComponent('GoogleCastButton')).toBe(GoogleCastButton);
+      expect(player.controlBar.GoogleCastButton).toBeDefined();
+      expect(GoogleCastButton.VERSION).toBeDefined();
+    });
+
+    it('should not hide the button if chrome is available', () => {
+      expect(player.controlBar.GoogleCastButton.hasClass('vjs-hidden')).toBeFalsy();
+    });
+
+    it('should call requestSession when clicked', () => {
+      player.controlBar.GoogleCastButton.handleClick();
+      expect(requestSessionSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/google-cast-sender/test/components/google-cast-launcher.spec.js
+++ b/packages/google-cast-sender/test/components/google-cast-launcher.spec.js
@@ -1,0 +1,82 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import videojs from 'video.js';
+import '../../src/google-cast-sender.js';
+import GoogleCastLauncher from '../../src/components/google-cast-launcher.js';
+import '../google-cast.mock.js';
+
+window.HTMLMediaElement.prototype.load = () => {
+};
+
+describe('GoogleCastLauncher', () => {
+  let player, videoElement;
+
+  beforeAll(() => {
+    document.body.innerHTML = '<video id="test-video" class="video-js"></video>';
+    videoElement = document.querySelector('#test-video');
+  });
+
+  describe('Google Cast not supported', () => {
+    let chromeBackup;
+
+    beforeAll(() => {
+      chromeBackup = window.chrome;
+      window.chrome = undefined;
+    });
+
+    beforeEach(() => {
+      player = videojs(videoElement, {
+        techOrder: ['chromecast', 'html5'],
+        plugins: { googleCastSender: true }
+      });
+    });
+
+    afterEach(() => {
+      player.dispose();
+    });
+
+    afterAll(() => {
+      window.chrome = chromeBackup;
+    });
+
+    it('should be registered and attached to the player', () => {
+      expect(videojs.getComponent('GoogleCastLauncher')).toBe(GoogleCastLauncher);
+      expect(player.controlBar.GoogleCastLauncher).toBeDefined();
+      expect(GoogleCastLauncher.VERSION).toBeDefined();
+    });
+
+    it('should hide the button if chrome is not available', () => {
+      expect(player.controlBar.GoogleCastLauncher.hasClass('vjs-hidden')).toBeTruthy();
+    });
+  });
+
+  describe('Google Cast supported', () => {
+    beforeEach(async() => {
+      player = videojs(videoElement, {
+        techOrder: ['chromecast', 'html5'],
+        plugins: { googleCastSender: true }
+      });
+
+      await new Promise((resolve) => player.ready(resolve));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      player.dispose();
+    });
+
+    it('should be registered and attached to the player', () => {
+      expect(videojs.getComponent('GoogleCastLauncher')).toBe(GoogleCastLauncher);
+      expect(player.controlBar.GoogleCastLauncher).toBeDefined();
+      expect(GoogleCastLauncher.VERSION).toBeDefined();
+    });
+
+    it('should not hide the button if chrome is available', () => {
+      expect(player.controlBar.GoogleCastLauncher.hasClass('vjs-hidden')).toBeFalsy();
+    });
+
+    it('should render an updated title on language change', () => {
+      player.language('fr');
+      expect(player.controlBar.GoogleCastLauncher.el().title).toBe('Utiliser Google Cast');
+    });
+  });
+});

--- a/packages/google-cast-sender/test/google-cast.mock.js
+++ b/packages/google-cast-sender/test/google-cast.mock.js
@@ -32,6 +32,7 @@ const castContextInstance = {
   setOptions: vi.fn(),
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
+  requestSession: vi.fn(),
   endCurrentSession: vi.fn(),
   getCurrentSession: vi.fn(() => getCurrentSession),
   getCastState: vi.fn(),

--- a/packages/google-cast-sender/vite.config.lib.js
+++ b/packages/google-cast-sender/vite.config.lib.js
@@ -1,6 +1,27 @@
 import { defineConfig } from 'vite';
 import babel from '@rollup/plugin-babel';
 import copy from 'rollup-plugin-copy';
+import * as process from 'node:process';
+
+const entryMap = {
+  sender: {
+    entry: 'src/google-cast-sender.js',
+    output: 'google-cast-sender',
+    outDir: 'dist',
+  },
+  button: {
+    entry: 'src/components/google-cast-launcher.js',
+    output: 'google-cast-button',
+    outDir: 'dist/button',
+  },
+  launcher: {
+    entry: 'src/components/google-cast-launcher.js',
+    output: 'google-cast-launcher',
+    outDir: 'dist/launcher',
+  },
+};
+const target = process.env.BUILD_TARGET;
+const { entry, output, outDir } = entryMap[target];
 
 /**
  * Vite's configuration for the lib build.
@@ -8,18 +29,32 @@ import copy from 'rollup-plugin-copy';
  * Outputs:
  * - 'dist/google-cast-sender.js': ESModule version with sourcemaps.
  * - 'dist/google-cast-sender.cjs': CommonJS version with sourcemaps.
+ * - 'dist/launcher/google-cast-launcher.js': ESModule version with sourcemaps.
+ * - 'dist/launcher/google-cast-launcher.cjs': CommonJS version with sourcemaps.
+ * - 'dist/button/google-cast-button.js': ESModule version with sourcemaps.
+ * - 'dist/button/google-cast-button.cjs': CommonJS version with sourcemaps.
  */
 export default defineConfig({
   esbuild: false,
   build: {
+    outDir: outDir,
     sourcemap: true,
     lib: {
       formats: ['es', 'cjs'],
-      name: 'GoogleCastSender',
-      entry: 'src/google-cast-sender.js'
+      entry: entry
     },
     rollupOptions: {
-      external: ['video.js'],
+      external: ['video.js', '@srgssr/svg-button'],
+      output: [
+        {
+          format: 'es',
+          entryFileNames: `${output}.js`
+        },
+        {
+          format: 'cjs',
+          entryFileNames: `${output}.cjs`
+        }
+      ],
       plugins: [
         babel({
           babelHelpers: 'bundled',

--- a/packages/google-cast-sender/vite.config.umd.js
+++ b/packages/google-cast-sender/vite.config.umd.js
@@ -1,6 +1,35 @@
 import { defineConfig } from 'vite';
 import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
+import process from 'node:process';
+
+const entryMap = {
+  sender: {
+    entry: 'src/google-cast-sender.js',
+    output: 'google-cast-sender',
+    outDir: 'dist',
+    name: 'GoogleCastSender',
+  },
+  button: {
+    entry: 'src/components/google-cast-launcher.js',
+    output: 'google-cast-button',
+    outDir: 'dist/button',
+    name: 'GoogleCastButton',
+  },
+  launcher: {
+    entry: 'src/components/google-cast-launcher.js',
+    output: 'google-cast-launcher',
+    outDir: 'dist/launcher',
+    name: 'GoogleCastLauncher',
+  },
+};
+const target = process.env.BUILD_TARGET;
+const {
+  entry,
+  output,
+  outDir,
+  name
+} = entryMap[target];
 
 /**
  * Vite's configuration for the umd build.
@@ -11,17 +40,18 @@ import terser from '@rollup/plugin-terser';
 export default defineConfig({
   esbuild: false,
   build: {
+    outDir: outDir,
     emptyOutDir: false,
     sourcemap: true,
     lib: {
       formats: ['umd'],
-      name: 'GoogleCastSender',
-      entry: 'src/google-cast-sender.js'
+      name: name,
+      entry: entry
     },
     rollupOptions: {
       output: {
-        name: 'GoogleCastSender',
-        entryFileNames: 'google-cast-sender.umd.min.js',
+        name: name,
+        entryFileNames: `${output}.umd.min.js`,
         globals: {
           videojs: 'videojs',
         },


### PR DESCRIPTION
## Description

Resolves #75 by introducing two new components:

- `GoogleCastButton`: a customizable Cast button based on SvgButton, allowing developers to integrate with their own visual identity. The icon can be customized via `icon` or `iconName`.
- `GoogleCastLauncher`: a wrapper around the native `<google-cast-launcher>` element for a plug-and-play experience.

Both buttons are automatically added to the Video.js control bar by default, and can be disabled via player options.

## Changes Made

The `enableDefaultCastButton` option has been removed. The default button behavior is now controlled by importing the launcher.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
