### PR TITLE
chore: run build on pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,4 @@
+npm run build
 npm test
 
 # Check for changes in the scripts folder

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ npm run prepare
 Ensure your code builds correctly before submitting a pull request:
 
 ```shell
-npm run build -ws # Build all the packages in the workspace
+npm run build # Build all the packages in the workspace
 npm run build -w @srgssr/your-element-name # Build a single page by name
 ```
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "create": "plop --plopfile scripts/create.js",
     "eslint": "eslint {packages/**/{src,test}/**/*.{js,jsx},scripts/*.{js,jsx}}",
+    "build": "npm run build -ws",
     "github:page": "npm run github:page --ws --if-present && vite build && node scripts/prepare-deployment.js",
     "start": " vite --host --port 4200 --open",
     "outdated": "npm outdated",


### PR DESCRIPTION
## Description

Resolves #83 by running `npm run build` on the pre-push hook.

## Changes Made

- Added `npm run build -ws` to the parent package script to make it easier to build the whole workspace.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
