### PR TITLE
chore(create): remove options from plugin generation

### DIFF
--- a/scripts/template/src/{{kebabCase name}}.js.hbs
+++ b/scripts/template/src/{{kebabCase name}}.js.hbs
@@ -17,10 +17,9 @@ class {{properCase name}} extends Plugin {
    * Creates an instance of a {{properCase name}}.
    *
    * @param {import('{{importAlias}}{{#ifEq platform 'pillarbox'}}').Player}{{else}}/dist/types/player.js').default}{{/ifEq}} player The player instance.
-   * @param {Object} options Configuration options for the plugin.
    */
-  constructor(player, options) {
-    super(player, options);
+  constructor(player) {
+    super(player);
   }
 
   static get VERSION() {


### PR DESCRIPTION
## Description

Resolves #82 by removing the options parameter on generated Plugins constructor.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
