### PR TITLE
fix(chapter-bar): chapter loading on apple firefox/google

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20465,7 +20465,7 @@
     },
     "packages/google-cast-sender": {
       "name": "@srgssr/google-cast-sender",
-      "version": "0.0.1",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@srgssr/pillarbox-web": "^1.23.1",

--- a/packages/chapters-bar/src/chapters-bar.js
+++ b/packages/chapters-bar/src/chapters-bar.js
@@ -38,12 +38,12 @@ class ChaptersBar extends Component {
   constructor(player, options) {
     super(player, options);
 
-    this.onLoadedData = this.onLoadedData.bind(this);
+    this.onAddChaptersTrack = this.onAddChaptersTrack.bind(this);
     this.onEmptied = this.onEmptied.bind(this);
     this.onChapterChange = this.onChapterChange.bind(this);
     this.userActive = this.userActive.bind(this);
 
-    this.player().on('loadeddata', this.onLoadedData);
+    this.player().textTracks().on('addtrack', this.onAddChaptersTrack);
     this.player().on('emptied', this.onEmptied);
     this.player().on('useractive', this.userActive);
     this.player().on('srgssr/chapter', this.onChapterChange);
@@ -192,11 +192,13 @@ class ChaptersBar extends Component {
   }
 
   /**
-   * Handles the `loadeddata` event.
+   * Handles the `addtrack` event.
    *
    * @private
    */
-  onLoadedData() {
+  onAddChaptersTrack({ track }) {
+    if (!track || track.id !== 'srgssr-chapters') return;
+
     const chapters = this.chapters();
 
     if (!chapters.length) return;
@@ -270,7 +272,7 @@ class ChaptersBar extends Component {
    */
   dispose() {
     this.onEmptied();
-    this.player().off('loadeddata', this.onLoadedData);
+    this.player().off('loadeddata', this.onAddChaptersTrack);
     this.player().off('emptied', this.onEmptied);
     this.player().off('useractive', this.userActive);
     this.player().on('srgssr/chapter', this.onChapterChange);

--- a/packages/chapters-bar/test/chapters-bar.spec.js
+++ b/packages/chapters-bar/test/chapters-bar.spec.js
@@ -45,9 +45,7 @@ describe('ChaptersBar', () => {
         { startTime: 10, endTime: 20, text: '{"urn":"urn:two","title":"Chapter 2"}' },
       ],
     };
-    player.textTracks = vi.fn(() => ({
-      getTrackById: vi.fn().mockReturnValue(textTrack),
-    }));
+    player.textTracks().getTrackById = vi.fn().mockReturnValue(textTrack);
   });
 
   afterEach(() => {
@@ -77,7 +75,7 @@ describe('ChaptersBar', () => {
     it('should return an empty array if no chapters track is found', () => {
       const chaptersBarComponent = new ChaptersBar(player, { chapterOptions: {} });
 
-      textTrack = undefined;
+      player.textTracks().getTrackById.mockReturnValueOnce(undefined);
 
       expect(chaptersBarComponent.chapters()).toEqual([]);
     });
@@ -91,13 +89,13 @@ describe('ChaptersBar', () => {
     });
   });
 
-  describe('loadeddata', () => {
+  describe('onAddChaptersTrack', () => {
     it('should add chapters and show the bar', () => {
       const chaptersBar = new ChaptersBar(player, { chapterOptions: {} });
       const addChapterSpy = vi.spyOn(chaptersBar, 'addChapter');
       const showSpy = vi.spyOn(chaptersBar, 'show');
 
-      player.trigger('loadeddata');
+      chaptersBar.onAddChaptersTrack({ track: textTrack });
 
       expect(addChapterSpy).toHaveBeenCalledTimes(2);
       expect(showSpy).toHaveBeenCalled();
@@ -105,11 +103,10 @@ describe('ChaptersBar', () => {
 
     it('should do nothing if there are no chapters', () => {
       const chaptersBar = new ChaptersBar(player, { chapterOptions: {} });
-
-      textTrack.cues = [];
       const addChapterSpy = vi.spyOn(chaptersBar, 'addChapter');
 
-      player.trigger('loadeddata');
+      chaptersBar.onAddChaptersTrack({});
+
       expect(addChapterSpy).not.toHaveBeenCalled();
     });
   });
@@ -118,7 +115,8 @@ describe('ChaptersBar', () => {
     it('should hide the bar and clear all chapters', () => {
       const chaptersBar = new ChaptersBar(player, { chapterOptions: {} });
 
-      player.trigger('loadeddata');
+      chaptersBar.onAddChaptersTrack({ track: textTrack });
+
       expect(chaptersBar.children()).toHaveLength(2);
 
       const hideSpy = vi.spyOn(chaptersBar, 'hide');
@@ -139,6 +137,7 @@ describe('ChaptersBar', () => {
       const chapterChangeEvent = { data: { text: '{"urn":"urn:two"}' } };
       const scrollToSelectedChapterSpy = vi.spyOn(chaptersBar, 'scrollToSelectedChapter');
 
+      chaptersBar.onAddChaptersTrack({ track: textTrack });
       chaptersBar.onChapterChange(chapterChangeEvent);
 
       const firstChild = chaptersBar.getChildById('urn:one');
@@ -155,7 +154,7 @@ describe('ChaptersBar', () => {
     it('should scroll to the selected chapter if it is selected', () => {
       const chaptersBar = new ChaptersBar(player, { chapterOptions: {} });
 
-      player.trigger('loadeddata');
+      chaptersBar.onAddChaptersTrack({ track: textTrack });
 
       const chapter = chaptersBar.getChildById('urn:one');
 
@@ -175,7 +174,7 @@ describe('ChaptersBar', () => {
     it('should not scroll if the chapter is not selected', () => {
       const chaptersBar = new ChaptersBar(player, { chapterOptions: {} });
 
-      player.trigger('loadeddata');
+      chaptersBar.onAddChaptersTrack({ track: textTrack });
 
       const chapter = chaptersBar.getChildById('urn:one');
 


### PR DESCRIPTION



## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->
Fixes #88 by changing the chapter loading mechanism to listen for the `addtrack` event on the `TextTrackList`. Previously, it relied on the player's `loadeddata` event, which could fire before the chapter track was available, leading to chapters not being displayed on Apple device when using Firefox or Chrome.
## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- rename `onLoadedData` to `onAddChaptersTrack`
- update unit tests
## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
