### PR TITLE
chore(cast): allow passing a receiver application ID as a parameter

### DIFF
--- a/packages/google-cast-sender/index.html
+++ b/packages/google-cast-sender/index.html
@@ -34,6 +34,7 @@
       const ilHost = searchParams.get("ilHost") || undefined;
       const language = searchParams.get("language");
       const urn = searchParams.get("urn") || "urn:rts:video:8806923";
+      const receiverId = searchParams.get("receiverId") || "1AC2931D";
 
       // Create a pillarbox player instance with the GoogleCastSender enabled
       window.player = pillarbox("player", {
@@ -46,7 +47,7 @@
         techOrder: ['chromecast', 'html5'],
         plugins: {
           googleCastSender: {
-            receiverApplicationId: '1AC2931D',
+            receiverApplicationId: receiverId,
             sourceResolver: (source) => {
               if (!source.mediaData) return source;
 


### PR DESCRIPTION
## Description

This PR allows us to pass a receiver application ID as a parameter, enabling us to test receivers other than the production one.

## Changes Made

- A `receiverId` parameter has been added.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
