### PR TITLE
feat(google-cast-sender): handle receiver paused event

### DIFF
--- a/packages/google-cast-sender/src/google-cast-tech.js
+++ b/packages/google-cast-sender/src/google-cast-tech.js
@@ -103,6 +103,7 @@ class Chromecast extends Tech {
     this.triggerWaiting(playerState);
     this.handleSeeking(playerState);
     this.handlePlaying(playerState);
+    this.handlePause(playerState);
     this.handleEnded(playerState);
   }
 
@@ -185,6 +186,18 @@ class Chromecast extends Tech {
     if (playerState.value === 'PLAYING') {
       this.trigger('play');
       this.trigger('playing');
+    }
+  }
+
+  /**
+   * Handle paused.
+   *
+   * @param {cast.framework.RemotePlayerChangedEvent} playerState the player
+   * state
+   */
+  handlePause(playerState) {
+    if (playerState.value === 'PAUSED') {
+      this.trigger('pause');
     }
   }
 

--- a/packages/google-cast-sender/test/google-cast-tech.spec.js
+++ b/packages/google-cast-sender/test/google-cast-tech.spec.js
@@ -233,6 +233,17 @@ describe('Chromecast', () => {
     });
   });
 
+  describe('handlePause', () => {
+    it('should trigger pause', () => {
+      const triggerSpy = vi.spyOn(tech, 'trigger');
+
+      tech.handlePause({
+        value: 'PAUSED'
+      });
+      expect(triggerSpy).toHaveBeenCalledWith('pause');
+    });
+  });
+
   describe('handleEnded', () => {
     it('should trigger ended', () => {
       const triggerSpy = vi.spyOn(tech, 'trigger');


### PR DESCRIPTION




## Description
Change the player's local state when a `PAUSED` event is emitted by the receiver.
<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- add a `handlePause` function
- add a test case
## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
