### PR TITLE
feat(google-cast-sender): add load method

### DIFF
--- a/packages/google-cast-sender/src/google-cast-tech.js
+++ b/packages/google-cast-sender/src/google-cast-tech.js
@@ -340,7 +340,7 @@ class Chromecast extends Tech {
   }
 
   load() {
-    // noop
+    this.loadMedia(this.currentSource_);
   }
 
   controls() {


### PR DESCRIPTION




## Description
Resolves #93 by reseting the media element to its initial state and prepare the media to start playback at the beginning.
<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->
- `load` calls `loadMedia` with the current source
## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
