### PR TITLE
feat(google-cast-sender): add the ability to replay media

### DIFF
--- a/packages/google-cast-sender/src/google-cast-tech.js
+++ b/packages/google-cast-sender/src/google-cast-tech.js
@@ -391,8 +391,10 @@ class Chromecast extends Tech {
   }
 
   ended() {
+    if(!this.src().src) return;
+
     return this.remotePlayer
-          && this.remotePlayer.playerState === 'IDLE' ? true : false;
+      && this.remotePlayer.playerState === 'IDLE' ? true : false;
   }
 
   muted() {
@@ -415,7 +417,15 @@ class Chromecast extends Tech {
   }
 
   play() {
-    if (this.remotePlayer && this.remotePlayer.isPaused) {
+    if (!this.remotePlayer) return;
+
+    if (this.ended()) {
+      this.load();
+
+      return;
+    }
+
+    if (this.remotePlayer.isPaused) {
       this.remotePlayerController.playOrPause();
       this.trigger('play');
       this.trigger('playing');

--- a/packages/google-cast-sender/test/google-cast-tech.spec.js
+++ b/packages/google-cast-sender/test/google-cast-tech.spec.js
@@ -86,6 +86,18 @@ describe('Chromecast', () => {
       tech.play();
       expect(playOrPauseSpy).toHaveBeenCalled();
     });
+
+    it('should call load when playback has ended to replay the media', () => {
+      const loadSpy = vi.spyOn(
+        tech,
+        'load'
+      );
+
+      vi.spyOn(tech, 'src').mockReturnValueOnce({ src: 'test.mp4'});
+      tech.remotePlayer.playerState = 'IDLE';
+      tech.play();
+      expect(loadSpy).toHaveBeenCalled();
+    });
   });
 
   describe('pause', () => {
@@ -244,11 +256,28 @@ describe('Chromecast', () => {
     });
   });
 
-  describe('getters', () => {
-    it('should return correct values', () => {
+  describe('ended', () => {
+    it('should return undefined if no source is loaded', () => {
+      vi.spyOn(tech, 'src').mockReturnValueOnce({});
+
+      expect(tech.ended()).toBeUndefined();
+    });
+
+    it('should return true if the receiver is IDLE', () => {
+      vi.spyOn(tech, 'src').mockReturnValueOnce({ src: 'test.mp4'});
       tech.remotePlayer.playerState = 'IDLE';
       expect(tech.ended()).toBe(true);
+    });
 
+    it('should return false if the receiver is not IDLE', () => {
+      vi.spyOn(tech, 'src').mockReturnValueOnce({ src: 'test.mp4'});
+      tech.remotePlayer.playerState = 'PAUSED';
+      expect(tech.ended()).toBe(false);
+    });
+  });
+
+  describe('getters', () => {
+    it('should return correct values', () => {
       tech.remotePlayer.isPaused = true;
       expect(tech.paused()).toBe(true);
 


### PR DESCRIPTION




## Description
Resolves #94 by adding the ability to replay the media when it reaches the end. This feature relies on the media that was previously loaded locally. The reason is that when the receiver reaches the end of playback, the media session is removed.
<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

## Changes Made
- update the `play` function to allow reloading the media when it reaches the end of playback and the `replay` button is shown
- update the `ended` function to return `undefined` if no source is loaded
- update unit tests
<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
