### PR TITLE
feat(pillarbox-playlist): replace default buttons with custom svg-button components

### DIFF
--- a/packages/pillarbox-playlist/README.md
+++ b/packages/pillarbox-playlist/README.md
@@ -149,7 +149,7 @@ The following event is emitted by the playlist plugin:
 | `changes.items`        | [`PlaylistItem[]`](#playlistitem) | The updated array of playlist items (if the playlist content has changed).      |
 | `changes.currentIndex` | `number`                          | The new index of the currently selected item (if the current item has changed). |
 
-**Example Usage:**
+##### `stagechanged` Usage Example
 
 ```javascript
 player.playlistPlugin().on('statechanged', ({ changes }) => {
@@ -173,12 +173,44 @@ interface for the playlist.
 When initializing the playlist-ui plugin, you can pass an `options` object that configures the
 behavior of the plugin. Here are the available options:
 
-| Option                                                  | Type      | Default            | Description                                                                                                                                                                                                                                                 |
-|---------------------------------------------------------|-----------|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `insertChildBefore`                                     | `string`  | `fullscreenToggle` | The control bar child name before which the playlist button should be inserted.                                                                                                                                                                             |
-| `pillarboxPlaylistMenuDialog`                           | `object`  | `{}`               | Configuration for the modal dialog component. This can take any modal dialog options available in video.js. [See Video.js ModalDialog Documentation](https://docs.videojs.com/tutorial-modal-dialog.html)                                                   |
-| `pillarboxPlaylistMenuDialog.pauseOnOpen`               | `boolean` | `false`            | If true, the player will pause when the modal dialog is opened.                                                                                                                                                                                             |
-| `pillarboxPlaylistMenuDialog.pillarboxPlaylistControls` | `object`  | `{}`               | Configuration for the control buttons within the modal. You can define the order of the buttons, remove buttons you don't need, or add new ones. [See Video.js Component Children Documentation](https://videojs.com/guides/components/#component-children) |
+| Option              | Type   | Default            | Description                                                                     |
+|---------------------|--------|--------------------|---------------------------------------------------------------------------------|
+| `insertChildBefore` | String | `fullscreenToggle` | The control bar child name before which the playlist button should be inserted. |
+
+The plugin automatically adds 2 new components to the player:
+
+- [`PillarboxPlaylistMenuDialog`][pillarbox-playlist-modal]: a custom
+  dialog that extends the ModalDialog class. This component is added to the root options of the
+  player, it can take any modal dialog options available in
+  video.js ([See Video.js ModalDialog Documentation][videojs-modal-doc]) as well as the following
+  options:
+
+| Option                      | Type      | Default | Description                                                                                                                                                                                                                                                 |
+ |-----------------------------|-----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `pauseOnOpen`               | `boolean` | `false` | If true, the player will pause when the modal dialog is opened.                                                                                                                                                                                             |
+| `pillarboxPlaylistControls` | `Object`  | `{}`    | Configuration for the control buttons within the modal. You can define the order of the buttons, remove buttons you don't need, or add new ones. [See Video.js Component Children Documentation](https://videojs.com/guides/components/#component-children) |
+
+- [`PillarboxPlaylistButton`][pillarbox-playlist-button.js] And [`SvgButton`][svg-button-api]
+  component added to the `controlBar` with the following default options:
+
+| Option        | Type   | Default    |
+ |---------------|--------|------------|
+| `iconName`    | String | `chapters` |
+| `controlText` | String | `Playlist` |
+
+###### Playlist Controls API
+
+The [`PillarboxPlaylistControls`][pillarbox-playlist-controls] component contains four children:
+
+| Button                                | Default `iconName` |
+|---------------------------------------|--------------------|
+| `pillarboxPlaylistRepeatButton`       | `'repeat'`         | 
+| `pillarboxPlaylistShuffleButton`      | `'shuffle'`        | 
+| `pillarboxPlaylistPreviousItemButton` | `'previous-item'`  | 
+| `pillarboxPlaylistNextItemButton`     | `'next-item`       |
+
+Each button extends the shared [`SvgButton`][svg-button-api] component. All `SvgButton` options are
+supported.
 
 ##### Playlist Item UI Data
 
@@ -195,7 +227,7 @@ The following fields in `item.data` are recognized and displayed automatically i
 Any additional properties stored in `item.data` are ignored by the UI but remain available for
 custom usage.
 
-***Example Usage***
+##### Playlist UI Plugin Usage Example
 
 ```javascript
 import Pillarbox from '@srgssr/pillarbox-web';
@@ -209,14 +241,19 @@ const player = new Pillarbox('my-player', {
     // Include the playlist UI plugin
     pillarboxPlaylistUI: {
       // Change the placement of the playlist button
-      inserChildBefore: 'subsCapsButton',
-      pillarboxPlaylistMenuDialog: {
-        // Force the playback to pause when the modal is opened
-        pauseOnOpen: true,
-        // Remove the shuffle  button 
-        pillarboxPlaylistControls: { pillarboxPlaylistShuffleButton: false }
-      }
+      inserChildBefore: 'subsCapsButton'
     }
+  },
+  // Change the Dialog options
+  pillarboxPlaylistMenuDialog: {
+    // Force the playback to pause when the modal is opened
+    pauseOnOpen: true,
+    // Remove the shuffle  button 
+    pillarboxPlaylistControls: { pillarboxPlaylistShuffleButton: false }
+  },
+  // Customize the look of the playlist button
+  controlBar: {
+    pillarboxPlaylistButton: { iconName: 'square' }
   }
 });
 
@@ -276,3 +313,8 @@ This project is licensed under the MIT License. See the [LICENSE](./LICENSE) fil
 details.
 
 [contributing-guide]: https://github.com/SRGSSR/pillarbox-web-suite/blob/main/docs/README.md#contributing
+[svg-button-api]: ../svg-button/README.md#api-documentation
+[pillarbox-playlist-modal]: ./src/components/modal/pillarbox-playlist-modal.js
+[videojs-modal-doc]: https://docs.videojs.com/tutorial-modal-dialog.html
+[pillarbox-playlist-controls]: ./src/components/modal/pillarbox-playlist-controls.js
+[pillarbox-playlist-button]: ./src/components/pillarbox-playlist-button.js

--- a/packages/pillarbox-playlist/package.json
+++ b/packages/pillarbox-playlist/package.json
@@ -51,6 +51,9 @@
     "start": " vite --port 4200 --open",
     "test": "vitest run --silent --coverage --coverage.reporter text"
   },
+  "dependencies": {
+    "@srgssr/svg-button": "^1.1.0"
+  },
   "peerDependencies": {
     "video.js": "^8.0.0"
   },

--- a/packages/pillarbox-playlist/scss/pillarbox-playlist.scss
+++ b/packages/pillarbox-playlist/scss/pillarbox-playlist.scss
@@ -1,3 +1,5 @@
+@import '@srgssr/svg-button/dist/svg-button.min.css';
+
 .pbw-playlist-button {
   cursor: pointer;
 }

--- a/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-next-item-button.js
+++ b/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-next-item-button.js
@@ -1,20 +1,19 @@
 import videojs from 'video.js';
+import '@srgssr/svg-button';
 
 /**
  * @ignore
- * @type {typeof import('video.js/dist/types/button').default}
+ * @type {typeof import('@srgssr/svg-button').SvgButton}
  */
-const Button = videojs.getComponent('Button');
+const SvgButton = videojs.getComponent('SvgButton');
 
 /**
  * The next item button for the playlist ui. When clicked moves to the
  * next item in the playlist.
  */
-class PillarboxPlaylistNextItemButton extends Button {
+class PillarboxPlaylistNextItemButton extends SvgButton {
   constructor(player, options) {
-    options = videojs.mergeOptions({ controlText: 'Next Item' }, options);
     super(player, options);
-    this.setIcon('next-item');
   }
 
   /**
@@ -24,10 +23,6 @@ class PillarboxPlaylistNextItemButton extends Button {
    */
   playlist() {
     return this.player().pillarboxPlaylist();
-  }
-
-  ready() {
-    this.$('.vjs-icon-placeholder').classList.toggle(`vjs-icon-next-item`, true);
   }
 
   /**
@@ -40,5 +35,10 @@ class PillarboxPlaylistNextItemButton extends Button {
     this.playlist().next();
   }
 }
+
+PillarboxPlaylistNextItemButton.prototype.options_ = {
+  controlText: 'Next Item',
+  iconName: 'next-item'
+};
 
 videojs.registerComponent('PillarboxPlaylistNextItemButton', PillarboxPlaylistNextItemButton);

--- a/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-repeat-button.js
+++ b/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-repeat-button.js
@@ -1,22 +1,21 @@
 import videojs from 'video.js';
+import '@srgssr/svg-button';
 import { RepeatMode } from '../../pillarbox-playlist.js';
 
 /**
  * @ignore
- * @type {typeof import('video.js/dist/types/button').default}
+ * @type {typeof import('@srgssr/svg-button').SvgButton}
  */
-const Button = videojs.getComponent('Button');
+const SvgButton = videojs.getComponent('SvgButton');
 
 /**
  * The repeat button for the playlist ui. When clicked toggles the repeat mode
  * of the playlist.
  */
-class PillarboxPlaylistRepeatButton extends Button {
+class PillarboxPlaylistRepeatButton extends SvgButton {
   constructor(player, options) {
-    options = videojs.mergeOptions({ controlText: 'Repeat' }, options);
     super(player, options);
     this.controlText(this.repeatModeAsString());
-    this.setIcon('repeat');
   }
 
   /**
@@ -26,10 +25,6 @@ class PillarboxPlaylistRepeatButton extends Button {
    */
   playlist() {
     return this.player().pillarboxPlaylist();
-  }
-
-  ready() {
-    this.$('.vjs-icon-placeholder').classList.toggle(`vjs-icon-repeat`, true);
   }
 
   repeatModeAsString() {
@@ -66,5 +61,9 @@ class PillarboxPlaylistRepeatButton extends Button {
     this.setAttribute('aria-pressed', !this.playlist().isNoRepeatMode());
   }
 }
+
+PillarboxPlaylistRepeatButton.prototype.options_ = {
+  iconName: 'repeat'
+};
 
 videojs.registerComponent('PillarboxPlaylistRepeatButton', PillarboxPlaylistRepeatButton);

--- a/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-shuffle-button.js
+++ b/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-shuffle-button.js
@@ -1,20 +1,19 @@
 import videojs from 'video.js';
+import '@srgssr/svg-button';
 
 /**
  * @ignore
- * @type {typeof import('video.js/dist/types/button').default}
+ * @type {typeof import('@srgssr/svg-button').SvgButton}
  */
-const Button = videojs.getComponent('Button');
+const SvgButton = videojs.getComponent('SvgButton');
 
 /**
  * The shuffle button for the playlist ui. When clicked shuffles the items
  * in the playlist.
  */
-class PillarboxPlaylistShuffleButton extends Button {
+class PillarboxPlaylistShuffleButton extends SvgButton {
   constructor(player, options) {
-    options = videojs.mergeOptions({ controlText: 'Shuffle' }, options);
     super(player, options);
-    this.setIcon('shuffle');
   }
 
   /**
@@ -24,10 +23,6 @@ class PillarboxPlaylistShuffleButton extends Button {
    */
   playlist() {
     return this.player().pillarboxPlaylist();
-  }
-
-  ready() {
-    this.$('.vjs-icon-placeholder').classList.toggle(`vjs-icon-shuffle`, true);
   }
 
   /**
@@ -40,5 +35,10 @@ class PillarboxPlaylistShuffleButton extends Button {
     this.playlist().shuffle();
   }
 }
+
+PillarboxPlaylistShuffleButton.prototype.options_ = {
+  controlText: 'Shuffle',
+  iconName: 'shuffle',
+};
 
 videojs.registerComponent('PillarboxPlaylistShuffleButton', PillarboxPlaylistShuffleButton);

--- a/packages/pillarbox-playlist/src/components/modal/pillarbox-previous-item-button.js
+++ b/packages/pillarbox-playlist/src/components/modal/pillarbox-previous-item-button.js
@@ -1,20 +1,19 @@
 import videojs from 'video.js';
+import '@srgssr/svg-button';
 
 /**
  * @ignore
- * @type {typeof import('video.js/dist/types/button').default}
+ * @type {typeof import('@srgssr/svg-button').SvgButton}
  */
-const Button = videojs.getComponent('Button');
+const SvgButton = videojs.getComponent('SvgButton');
 
 /**
  * The previous item button for the playlist ui. When clicked moves to the
  * previous item in the playlist.
  */
-class PillarboxPlaylistPreviousItemButton extends Button {
+class PillarboxPlaylistPreviousItemButton extends SvgButton {
   constructor(player, options) {
-    options = videojs.mergeOptions({ controlText: 'Previous Item' }, options);
     super(player, options);
-    this.setIcon('previous-item');
   }
 
   /**
@@ -24,10 +23,6 @@ class PillarboxPlaylistPreviousItemButton extends Button {
    */
   playlist() {
     return this.player().pillarboxPlaylist();
-  }
-
-  ready() {
-    this.$('.vjs-icon-placeholder').classList.toggle(`vjs-icon-previous-item`, true);
   }
 
   /**
@@ -40,5 +35,10 @@ class PillarboxPlaylistPreviousItemButton extends Button {
     this.playlist().previous();
   }
 }
+
+PillarboxPlaylistPreviousItemButton.prototype.options_ = {
+  controlText: 'Previous Item',
+  iconName: 'previous-item',
+};
 
 videojs.registerComponent('PillarboxPlaylistPreviousItemButton', PillarboxPlaylistPreviousItemButton);

--- a/packages/pillarbox-playlist/src/components/pillarbox-playlist-button.js
+++ b/packages/pillarbox-playlist/src/components/pillarbox-playlist-button.js
@@ -1,15 +1,16 @@
 import videojs from 'video.js';
+import '@srgssr/svg-button';
 
 /**
  * @ignore
- * @type {typeof import('video.js/dist/types/button').default}
+ * @type {typeof import('@srgssr/svg-button').SvgButton}
  */
-const Button = videojs.getComponent('Button');
+const SvgButton = videojs.getComponent('SvgButton');
 
 /**
  * Class representing a button that opens the playlist menu.
  */
-class PillarboxPlaylistButton extends Button {
+class PillarboxPlaylistButton extends SvgButton {
   /**
    * Handles the 'statechanged' event when triggered by the playlist. This method
    * serves as a proxy to the main `statechanged` handler, ensuring that additional
@@ -30,9 +31,7 @@ class PillarboxPlaylistButton extends Button {
    * @param {Object} options - Options for the button.
    */
   constructor(player, options) {
-    options = videojs.mergeOptions({ controlText: 'Playlist' }, options);
     super(player, options);
-    this.setIcon('chapters');
     this.playlist().on('statechanged', this.onPlaylistStateChanged_);
   }
 
@@ -43,10 +42,6 @@ class PillarboxPlaylistButton extends Button {
    */
   playlist() {
     return this.player().pillarboxPlaylist();
-  }
-
-  ready() {
-    this.$('.vjs-icon-placeholder').classList.toggle('vjs-icon-chapters', true);
   }
 
   /**
@@ -89,5 +84,10 @@ class PillarboxPlaylistButton extends Button {
     this.hide();
   }
 }
+
+PillarboxPlaylistButton.prototype.options_ = {
+  controlText: 'Playlist',
+  iconName: 'chapters'
+};
 
 videojs.registerComponent('PillarboxPlaylistButton', PillarboxPlaylistButton);

--- a/packages/pillarbox-playlist/src/pillarbox-playlist-ui.js
+++ b/packages/pillarbox-playlist/src/pillarbox-playlist-ui.js
@@ -22,8 +22,6 @@ class PillarboxPlaylistUI extends Plugin {
    * @param {Player} player - The video.js player instance.
    * @param {Object} options - Plugin options.
    * @param {string} [options.insertChildBefore='fullscreenToggle'] - The control bar child name before which the playlist button should be inserted.
-   * @param {Object} [options.pillarboxPlaylistButton={}] - Configuration for the playlist button.
-   * @param {Object} [options.pillarboxPlaylistMenuDialog={}] - Configuration for the modal dialog component. This can take any modal dialog options available in video.js.
    */
   constructor(player, options) {
     super(player);
@@ -37,7 +35,8 @@ class PillarboxPlaylistUI extends Plugin {
     options = this.options_ = videojs.obj.merge(this.options_, options);
 
     player.options({
-      pillarboxPlaylistMenuDialog: options.pillarboxPlaylistMenuDialog ?? true,
+      pillarboxPlaylistMenuDialog:
+        player.options().pillarboxPlaylistMenuDialog ?? true,
       controlBar: this.mergeControlBarOptions(player, options)
     });
   }
@@ -79,7 +78,7 @@ class PillarboxPlaylistUI extends Plugin {
     }
 
     controlBarOptions.pillarboxPlaylistButton =
-      options.pillarboxPlaylistButton ?? true;
+      controlBarOptions.pillarboxPlaylistButton ?? true;
 
     return controlBarOptions;
   }

--- a/packages/pillarbox-playlist/vite.config.ui.js
+++ b/packages/pillarbox-playlist/vite.config.ui.js
@@ -20,7 +20,7 @@ export default defineConfig({
       entry: 'src/pillarbox-playlist-ui.js'
     },
     rollupOptions: {
-      external: ['video.js'],
+      external: ['video.js', '@srgssr/svg-button'],
       output: [
         {
           format: 'es',


### PR DESCRIPTION
## Description

Resolves https://github.com/SRGSSR/pillarbox-web-suite/issues/81 by replacing the usage of the videojs default button components with our own `SvgButton` component . This allows for more consistent customization.

**BREAKING CHANGE:** plugin options for dialog/buttons configuration are no longer passed through plugin options but via player root and controlBar options.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
