### PR TITLE
fix(svg-button): icon property should take precedence over icon name

### DIFF
--- a/packages/svg-button/src/svg-icon-loader.js
+++ b/packages/svg-button/src/svg-icon-loader.js
@@ -7,9 +7,11 @@ import { loadSvgElement } from '@srgssr/web-suite-utils';
  */
 export async function appendSvgIcon(component) {
   const { icon, iconName } = component.options();
-  const placeholder = component.el().querySelector('.vjs-icon-placeholder');
 
   if (iconName) component.setIcon(iconName);
+
+  const placeholder = component.el().querySelector('.vjs-icon-placeholder');
+
   if (iconName && placeholder) placeholder.classList.toggle(`vjs-icon-${iconName}`, true);
 
   await insertSvgIcon(icon, placeholder);

--- a/packages/svg-button/test/svg-button.spec.js
+++ b/packages/svg-button/test/svg-button.spec.js
@@ -18,7 +18,7 @@ describe('SvgButton', () => {
   describe('The SVG icon is provided', () => {
     beforeEach(() => {
       player = videojs(videoElement, {
-        svgButton: { icon: icon }
+        svgButton: { icon }
       });
     });
 
@@ -106,6 +106,29 @@ describe('SvgButton', () => {
 
       expect(use).toBeDefined();
       expect(use.getAttribute('href')).toBe('#vjs-icon-my-button');
+    });
+  });
+
+  describe('`icon` property should take precedence over `iconName` when experimental SVG is enabled', () => {
+    beforeEach(() => {
+      player = videojs(videoElement, {
+        experimentalSvgIcons: true,
+        svgButton: { icon, iconName: 'my-button' }
+      });
+    });
+
+    afterEach(() => {
+      player.dispose();
+    });
+
+    it('should contain an <svg> element instead of a <use> element', () => {
+      const use = player.svgButton.el().querySelector('use');
+      const svg = player.svgButton.el().querySelector('.icon-from-options');
+
+      expect(use).toBeNull();
+      expect(svg).toBeDefined();
+      expect(svg).toBeInstanceOf(SVGElement);
+
     });
   });
 

--- a/packages/svg-button/test/svg-component.spec.js
+++ b/packages/svg-button/test/svg-component.spec.js
@@ -92,6 +92,29 @@ describe('SvgComponent', () => {
     });
   });
 
+  describe('`icon` property should take precedence over `iconName` when experimental SVG is enabled', () => {
+    beforeEach(() => {
+      player = videojs(videoElement, {
+        experimentalSvgIcons: true,
+        svgComponent: { icon, iconName: 'my-button' }
+      });
+    });
+
+    afterEach(() => {
+      player.dispose();
+    });
+
+    it('should contain an <svg> element instead of a <use> element', () => {
+      const use = player.svgComponent.el().querySelector('use');
+      const svg = player.svgComponent.el().querySelector('.icon-from-options');
+
+      expect(use).toBeNull();
+      expect(svg).toBeDefined();
+      expect(svg).toBeInstanceOf(SVGElement);
+
+    });
+  });
+
   describe('Icon loaded as a font icon', () => {
     beforeEach(() => {
       player = videojs(videoElement, {


### PR DESCRIPTION
## Description

Makes sure that the icon property takes precedence over the iconName for the `SvgButton` and `SvgComponent` components.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
