### PR TITLE
fix(google-cast-sender): android receiver seeked state

### DIFF
--- a/packages/google-cast-sender/src/google-cast-tech.js
+++ b/packages/google-cast-sender/src/google-cast-tech.js
@@ -170,7 +170,15 @@ class Chromecast extends Tech {
    * state
    */
   handleSeeking(playerState) {
-    if (playerState.field === 'videoInfo' && !this.scrubbing() && this.isSeeking) {
+    // On the web receiver, the `field` property containing the value `videoInfo`
+    // allows, when combined with the other values, determining that a seek
+    // operation has finished, even when the media is paused. This prevents a
+    // spinner from continuing to spin while waiting for playback to resume,
+    // even though the seek operation has already completed.
+
+    // On the Android receiver, however, the `field` property containing `videoInfo`
+    // does not seem to be emitted, so the `mediaInfo` is used instead.
+    if (['mediaInfo', 'videoInfo'].includes(playerState.field) && !this.scrubbing() && this.isSeeking) {
       this.isSeeking = false;
       this.trigger('seeked');
     }


### PR DESCRIPTION
## Description

On the Android receiver, during a seek, the `playerState` object returned by the `anyChanged` event does not appear to include a `field` property containing the value `videoInfo`. As a result, the seek operation never completes, leaving a spinner displayed and the time no longer updating.
<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

## Changes Made
- add the value `mediaInfo` to check if the seek operation has finished even when the player is paused
<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
