### PR TITLE
feat: add start time support for playlist items

### DIFF
--- a/packages/pillarbox-playlist/README.md
+++ b/packages/pillarbox-playlist/README.md
@@ -118,11 +118,12 @@ The following properties are read-only:
 
 Represents a single item in the playlist.
 
-| Property  | Type     | Description                                                                                                      |
-|-----------|----------|------------------------------------------------------------------------------------------------------------------|
-| `sources` | `any[]`  | The array of media sources for the playlist item.                                                                |
-| `poster`  | `string` | A URL for the poster image.                                                                                      |
-| `data`    | `Object` | Metadata for the playlist item, where you can store fields like `title`, `duration`, or other custom properties. |
+| Property    | Type     | Description                                                                                                      |
+|-------------|----------|------------------------------------------------------------------------------------------------------------------|
+| `sources`   | `any[]`  | The array of media sources for the playlist item.                                                                |
+| `poster`    | `string` | A URL for the poster image.                                                                                      |
+| `data`      | `Object` | Metadata for the playlist item, where you can store fields like `title`, `duration`, or other custom properties. |
+| `startTime` | `number` | The time (in seconds) at which playback should begin for this item.                                              |
 
 #### Constants
 

--- a/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
+++ b/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
@@ -42,6 +42,7 @@ const playlist = [
       type: 'test'
     }],
     poster: 'fourth-poster',
+    startTime: 100,
     data: {
       title: 'fourth-source',
       duration: 210
@@ -744,6 +745,50 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(0);
       expect(pillarboxPlaylist.currentIndex).toBe(-1);
       expect(pillarboxPlaylist.currentItem).toBeUndefined();
+    });
+  });
+
+  describe('startTime', () => {
+    it('should seek to the item startTime on loadeddata', () => {
+      // Given
+      const currentTimeSpy = vi.spyOn(player, 'currentTime').mockImplementation(() => {
+      });
+      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
+      });
+      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      });
+
+      // When
+      pillarboxPlaylist.load(playlist);
+      pillarboxPlaylist.select(3);
+      pillarboxPlaylist.handleLoadedData();
+
+      // Then
+      expect(pillarboxPlaylist.currentItem).toBe(playlist[3]);
+      expect(srcSpy).toHaveBeenLastCalledWith(playlist[3].sources);
+      expect(posterSpy).toHaveBeenLastCalledWith(playlist[3].poster);
+      expect(currentTimeSpy).toHaveBeenLastCalledWith(playlist[3].startTime);
+    });
+
+    it('should not seek if no startTime is defined on the current item', () => {
+      // Given
+      const currentTimeSpy = vi.spyOn(player, 'currentTime').mockImplementation(() => {
+      });
+      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
+      });
+      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      });
+
+      // When
+      pillarboxPlaylist.load(playlist);
+      pillarboxPlaylist.select(2);
+      pillarboxPlaylist.handleLoadedData();
+
+      // Then
+      expect(pillarboxPlaylist.currentItem).toBe(playlist[2]);
+      expect(srcSpy).toHaveBeenLastCalledWith(playlist[2].sources);
+      expect(posterSpy).toHaveBeenLastCalledWith(playlist[2].poster);
+      expect(currentTimeSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description

Resolves #79 by introducing the `startTime` property (in seconds) to playlist items, allowing playback to begin from a specified position.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
