### PR TITLE
fix(thumbnail-preview): prevent image creation when sprite url is missing

### DIFF
--- a/packages/thumbnail-preview/src/components/thumbnail-preview-overlay.js
+++ b/packages/thumbnail-preview/src/components/thumbnail-preview-overlay.js
@@ -89,7 +89,7 @@ class ThumbnailPreviewOverlay extends Component {
     if (sprite && sprite.url) {
       this.initListeners();
       this.resizeThumbnail();
-      this.thumbnail.src = this.options().sprite.url;
+      this.thumbnail.src = sprite.url ?? '';
       this.updateThumbnailVisibility();
     } else {
       this.resetSprite();
@@ -307,10 +307,7 @@ class ThumbnailPreviewOverlay extends Component {
       throw new Error(`'${tag}' is not supported for ThumbnailPreview`);
     }
 
-    this.thumbnail = videojs.dom.createEl('img', {
-      className: 'pbw-thumbnail',
-      src: this.options().sprite.url
-    });
+    this.thumbnail = this.createThumbnailEl();
 
     return videojs.dom.createEl(
       tag,
@@ -318,6 +315,19 @@ class ThumbnailPreviewOverlay extends Component {
       attributes,
       this.thumbnail
     );
+  }
+
+  /**
+   * Creates the thumbnail <img> element.
+   * Uses the sprite URL if defined, or an empty string otherwise.
+   *
+   * @returns {HTMLImageElement}
+   */
+  createThumbnailEl() {
+    return videojs.dom.createEl('img', {
+      className: 'pbw-thumbnail',
+      src: this.options().sprite?.url ?? ''
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

Resolves https://github.com/SRGSSR/pillarbox-web-suite/issues/107 by ensuring that the thumbnail <img> element is not created or updated with an undefined URL.

Previously, an empty `src` attribute caused the browser to request the current page URL, leading to unnecessary network requests.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
