### PR TITLE
feat: display live label livestream items

### DIFF
--- a/packages/pillarbox-playlist/index.html
+++ b/packages/pillarbox-playlist/index.html
@@ -51,6 +51,7 @@
     'urn:srf:video:05457f66-fd67-4131-8e0a-6d85743efc39',
     'urn:rtr:video:33136b80-bec6-40cd-a771-b8954c805098',
     'urn:rts:video:9883196',
+    'urn:rts:video:3608506'
   ];
 
   Promise.all(sources.map(async urn => {
@@ -62,6 +63,7 @@
       data: {
         title: mainChapter.title,
         duration: mainChapter.duration / 1000,
+        live: mainChapter.type === 'LIVESTREAM',
         imageUrl: mainChapter.imageUrl,
         imageTitle: mainChapter.imageTitle
       },

--- a/packages/pillarbox-playlist/scss/pillarbox-playlist.scss
+++ b/packages/pillarbox-playlist/scss/pillarbox-playlist.scss
@@ -61,10 +61,14 @@
       .vjs-card-duration {
         position: absolute;
         top: 4em;
-        left: 6.5em;
+        right: 17em;
         color: white;
         background-color: rgb(0, 0, 0, 0.5);
         padding-inline: 0.5em;
+
+        &.vjs-card-duration-live {
+          background-color: rgb(255, 0, 0, 0.5);
+        }
       }
     }
   }

--- a/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-menu-item.js
+++ b/packages/pillarbox-playlist/src/components/modal/pillarbox-playlist-menu-item.js
@@ -3,7 +3,7 @@ import '@srgssr/card';
 
 /**
  * @ignore
- * @type {typeof import('video.js/dist/types/button').default}
+ * @type {typeof import('@srgssr/card').CardButton}
  */
 const CardButton = videojs.getComponent('CardButton');
 
@@ -16,6 +16,9 @@ class PillarboxPlaylistMenuItem extends CardButton {
    * @param {Object} player - The video.js player instance.
    * @param {Object} options - Options for the menu item.
    * @param {number} options.index - The index of the playlist item.
+   * @param {number} options.metadata.live - Whether the playlist item is a livestream.
+   *        If true, the duration element will display "Live" as text and the class
+   *        `vjs-card-duration-live` will be added to the element.
    */
   constructor(player, options) {
     super(player, options);
@@ -29,6 +32,17 @@ class PillarboxPlaylistMenuItem extends CardButton {
    */
   playlist() {
     return this.player().pillarboxPlaylist();
+  }
+
+  createDuration() {
+    const durationEl = super.createDuration();
+
+    if (this.options().metadata.live) {
+      durationEl.textContent = 'Live';
+      durationEl.classList.add('vjs-card-duration-live');
+    }
+
+    return durationEl;
   }
 
   /**


### PR DESCRIPTION
## Description

Resolves https://github.com/SRGSSR/pillarbox-web-suite/issues/78 by adding support for the `metadata.live` option in playlist items.

## Changes Made

- When `metadata.live` is true, the duration element now displays "Live" instead, and the `vjs-card-duration-live` class is added for styling purposes.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
