### PR TITLE
fix(card): prevent undefined src in img in card element

### DIFF
--- a/packages/card/src/card.js
+++ b/packages/card/src/card.js
@@ -102,8 +102,8 @@ class Card extends ClickableComponent {
       undefined,
       {
         class: 'vjs-card-img',
-        alt: this.options().metadata.imageTitle,
-        src: this.options().metadata.imageUrl
+        alt: this.options().metadata.imageTitle ?? '',
+        src: this.options().metadata.imageUrl ?? ''
       }
     );
   }


### PR DESCRIPTION
## Description

Ensures that the <img> element is not created with an undefined URL.

Previously, an undefined `src` attribute caused the browser to request the current page URL, leading to unnecessary network requests. The `alt` attribute follows the same logic, to avoid displaying "undefined" as an alt text.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
