### PR TITLE
fix(google-cast-sender): empty track restoration

### DIFF
--- a/packages/google-cast-sender/src/google-cast-sender.js
+++ b/packages/google-cast-sender/src/google-cast-sender.js
@@ -301,13 +301,17 @@ class GoogleCastSender extends Plugin {
    * @param {TextTrack} textTrack the text track to restore
    */
   restoreTracks(audioTrack, textTrack) {
-    this.trackListToArray(this.player.audioTracks()).forEach(track => {
-      track.enabled = track.language === audioTrack.language;
-    });
+    if (audioTrack) {
+      this.trackListToArray(this.player.audioTracks()).forEach(track => {
+        track.enabled = track.language === audioTrack.language;
+      });
+    }
 
-    this.trackListToArray(this.player.textTracks()).forEach(track => {
-      track.mode = textTrack && track.language === textTrack.language ? 'showing' : 'disabled';
-    });
+    if (textTrack) {
+      this.trackListToArray(this.player.textTracks()).forEach(track => {
+        track.mode = textTrack && track.language === textTrack.language ? 'showing' : 'disabled';
+      });
+    }
   }
 
   /**

--- a/packages/google-cast-sender/test/google-cast-sender.spec.js
+++ b/packages/google-cast-sender/test/google-cast-sender.spec.js
@@ -309,4 +309,42 @@ describe('GoogleCastSender', () => {
       expect(window.__onGCastApiAvailable).toBeUndefined();
     });
   });
+
+  describe('restoreTracks', () => {
+    it('should not try to restore the audio track if empty', () => {
+      const audioTrack = undefined;
+      const textTrack = { language: 'fr', mode: 'showing' };
+      const trackListToArraySpy = vi.spyOn(googleCastSender, 'trackListToArray');
+
+      player.audioTracks = vi.fn(()=>([]));
+      player.textTracks = vi.fn(()=>([]));
+
+      googleCastSender.restoreTracks(audioTrack, textTrack);
+
+      expect(trackListToArraySpy).toHaveBeenCalledOnce();
+      expect(player.audioTracks).not.toHaveBeenCalled();
+      expect(player.textTracks).toHaveBeenCalled();
+
+      player.audioTracks.mockRestore();
+      player.textTracks.mockRestore();
+    });
+
+    it('should not try to restore the text track if empty', () => {
+      const audioTrack = { language: 'en', enabled: true };
+      const textTrack = undefined;
+      const trackListToArraySpy = vi.spyOn(googleCastSender, 'trackListToArray');
+
+      player.audioTracks = vi.fn(()=>([]));
+      player.textTracks = vi.fn(()=>([]));
+
+      googleCastSender.restoreTracks(audioTrack, textTrack);
+
+      expect(trackListToArraySpy).toHaveBeenCalledOnce();
+      expect(player.audioTracks).toHaveBeenCalled();
+      expect(player.textTracks).not.toHaveBeenCalled();
+
+      player.audioTracks.mockRestore();
+      player.textTracks.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

When the media initially loaded by the local player is changed dynamically and the user starts a cast session, then refreshes the sender page, and finally stops the cast session, the local player may receive an empty audio or text track, causing an error when attempting to restore the audio or text track.

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- add a condition to restore the audio or text track only when it is not empty

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
