### PR TITLE
fix(google-cast-sender): default poster displayed

### DIFF
--- a/packages/google-cast-sender/src/google-cast-tech.js
+++ b/packages/google-cast-sender/src/google-cast-tech.js
@@ -460,7 +460,7 @@ class Chromecast extends Tech {
   poster() {
     const remotePoster = this.remotePlayer && this.remotePlayer.imageUrl;
 
-    return this.options().poster || remotePoster;
+    return remotePoster || this.options().poster;
   }
 
   src(source) {


### PR DESCRIPTION
## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

When the media initially loaded on the Google Cast receiver is changed and the sender tab is refreshed, the displayed poster may still be the poster from the initial media. The reason was that the local player's poster was preferred over the receiver's.

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- use the poster from the receiver by default

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
