### PR TITLE
feat(pillarbox-playlist): skip playlist item on error

### DIFF
--- a/packages/pillarbox-playlist/README.md
+++ b/packages/pillarbox-playlist/README.md
@@ -17,7 +17,7 @@ To get started with this plugin, install it through the following command:
 ```bash
 npm install --save @srgssr/pillarbox-web @srgssr/pillarbox-playlist
 ```
-
+  
 For instructions on setting up Pillarbox, see
 the [Quick Start guide](https://github.com/SRGSSR/pillarbox-web#quick-start).
 
@@ -88,23 +88,25 @@ The following table outlines the key methods available in this plugin:
 When initializing the playlist plugin, you can pass an `options` object that configures the
 behavior of the plugin. Here are the available options:
 
-| Option                        | Type                             | Default | Description                                                                                 |
-|-------------------------------|----------------------------------|---------|---------------------------------------------------------------------------------------------|
-| `playlist`                    | [`PlaylistItem](#playlistitem)[] | `[]`    | An array of playlist items to be initially loaded into the player.                          |
-| `repeat`                      | `number`                         | 0       | Set the repeat mode of the playlist: 0 - No Repeat, 1 - Repeat All, 2 - Repeat one.         |
-| `autoadvance`                 | `boolean`                        | `false` | If enabled, the player will automatically move to the next item after the current one ends. |
-| `previousNavigationThreshold` | `number`                         | 3       | Threshold in seconds for determining the behavior when navigating to the previous item.     |
+| Option                        | Type                                 | Default                      | Description                                                                                 |
+|-------------------------------|--------------------------------------|------------------------------|---------------------------------------------------------------------------------------------|
+| `playlist`                    | [`PlaylistItem`](#playlistitem)[]    | `[]`                         | An array of playlist items to be initially loaded into the player.                          |
+| `repeat`                      | `number`                             | 0                            | Set the repeat mode of the playlist: 0 - No Repeat, 1 - Repeat All, 2 - Repeat one.         |
+| `autoadvance`                 | `boolean`                            | `false`                      | If enabled, the player will automatically move to the next item after the current one ends. |
+| `previousNavigationThreshold` | `number`                             | 3                            | Threshold in seconds for determining the behavior when navigating to the previous item.     |
+| `skipOnError`                 | [`SkipOnErrorOptions`](#skiponerror) | `{enabled: true, delay: 60}` | Configuration for automatic skipping of playlist items when an error occurs.                |
 
 #### Properties
 
 After initializing the plugin, you can modify or read these properties to control playlist behavior
 dynamically:
 
-| Property                      | Type      | Description                                                                                  |
-|-------------------------------|-----------|----------------------------------------------------------------------------------------------|
-| `repeat`                      | `number`  | Changes the repeat mode of the playlist: 0 - No Repeat, 1 - Repeat All, 2 - Repeat one.    . |
-| `autoadvance`                 | `boolean` | Toggles automatic advancement to the next item when the current item ends.                   |
-| `previousNavigationThreshold` | `number`  | Threshold in seconds for determining the behavior when navigating to the previous item.      |
+| Property                      | Type                                 | Description                                                                                  |
+|-------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------|
+| `repeat`                      | `number`                             | Changes the repeat mode of the playlist: 0 - No Repeat, 1 - Repeat All, 2 - Repeat one.    . |
+| `autoadvance`                 | `boolean`                            | Toggles automatic advancement to the next item when the current item ends.                   |
+| `previousNavigationThreshold` | `number`                             | Threshold in seconds for determining the behavior when navigating to the previous item.      |
+| `skipOnError`                 | [`SkipOnErrorOptions`](#skiponerror) | Configuration for automatic skipping of playlist items when an error occurs.                 |
 
 The following properties are read-only:
 
@@ -124,6 +126,15 @@ Represents a single item in the playlist.
 | `poster`    | `string` | A URL for the poster image.                                                                                      |
 | `data`      | `Object` | Metadata for the playlist item, where you can store fields like `title`, `duration`, or other custom properties. |
 | `startTime` | `number` | The time (in seconds) at which playback should begin for this item.                                              |
+
+#### SkipOnError
+
+Configuration for automatic skipping of playlist items when an error occurs.
+
+| Property  | Type      | Description                                                                |
+|-----------|-----------|----------------------------------------------------------------------------|
+| `enabled` | `boolean` | Whether the player should automatically skip to the next playlist item.    |
+| `delay`   | `number`  | The delay in milliseconds before skipping to the next item after an error. |
 
 #### Constants
 

--- a/packages/pillarbox-playlist/index.html
+++ b/packages/pillarbox-playlist/index.html
@@ -46,6 +46,8 @@
     }
   });
 
+  player.pillarboxPlaylist().on('itemskipped', (e) => console.log(e));
+
   const sources = [
     'urn:rts:video:14827742',
     'urn:srf:video:05457f66-fd67-4131-8e0a-6d85743efc39',
@@ -70,6 +72,15 @@
       poster: mainChapter.imageUrl
     };
   })).then(playlist => {
+    const poisonPill = {
+      sources: [{ src: 'urn:srgssr:THIS_WILL_FAIL', type: 'srgssr/urn' }],
+      data: {
+        title: 'Poison Pill',
+        duration: 123,
+        live: false
+      }
+    };
+    playlist.splice(2, 0, poisonPill);
     // Load the video sources for the player
     player.pillarboxPlaylist().load(playlist);
   });

--- a/packages/pillarbox-playlist/src/pillarbox-playlist.js
+++ b/packages/pillarbox-playlist/src/pillarbox-playlist.js
@@ -148,6 +148,26 @@ export class PillarboxPlaylist extends Plugin {
   onLoadedData_ = () => this.handleLoadedData();
 
   /**
+   * The skip on error configuration.
+   *
+   * @type {SkipOnErrorOptions}
+   */
+  skipOnError = {
+    enabled: true,
+    delay: 60
+  };
+
+  skipOnErrorTimeoutId_;
+  /**
+   * Handles the 'error' event when triggered. This method serves as a
+   * proxy to the main `loaded` handler, ensuring that additional logic can be
+   * executed or making it easier to detach the event listener later.
+   *
+   * @private
+   */
+  onError_ = () => this.handleError();
+
+  /**
    * Creates an instance of a pillarbox playlist.
    *
    * @param {import('video.js/dist/types/player.js').default} player - The player instance.
@@ -155,6 +175,7 @@ export class PillarboxPlaylist extends Plugin {
    * @param {Array} [options.playlist=[]] - An array of playlist items to be initially loaded into the player.
    * @param {Boolean} [options.repeat=false] - If true, the playlist will start over automatically after the last item ends.
    * @param {Boolean} [options.autoadvance=false] - If enabled, the player will automatically move to the next item after the current one ends.
+   * @param {SkipOnErrorOptions} [options.skipOnError={enabled: true, delay: 60}] - If enabled, the player will automatically move to the next item after an error occurs with the current item.
    * @param {Number} [options.previousNavigationThreshold=3] - Threshold in seconds for determining the behavior when navigating to the previous item.
    */
   constructor(player, options) {
@@ -165,20 +186,29 @@ export class PillarboxPlaylist extends Plugin {
       player.ready(() => this.load(options.playlist));
     }
 
+    this.initPlugin(options);
+  }
+
+  initPlugin(options) {
     this.autoadvance = Boolean(options.autoadvance);
     this.repeat = options.repeat ?? this.repeat;
+    this.skipOnError = options.skipOnError ?? this.skipOnError;
+
     this.previousNavigationThreshold =
       Number.isFinite(options.previousNavigationThreshold) ?
-      options.previousNavigationThreshold :
-      this.previousNavigationThreshold;
+        options.previousNavigationThreshold :
+        this.previousNavigationThreshold;
 
     this.player.on('ended', this.onEnded_);
     this.player.on('loadeddata', this.onLoadedData_);
+    this.player.on('error', this.onError_);
   }
 
   dispose() {
+    this.player.clearTimeout(this.skipOnErrorTimeoutId_);
     this.player.off('ended', this.onEnded_);
     this.player.off('loadeddata', this.onLoadedData_);
+    this.player.off('error', this.onError_);
   }
 
   /**
@@ -351,6 +381,7 @@ export class PillarboxPlaylist extends Plugin {
 
     const item = this.items_[index];
 
+    this.player.clearTimeout(this.skipOnErrorTimeoutId_);
     this.player.src(item.sources);
     this.player.poster(item.poster);
     this.currentIndex_ = index;
@@ -503,11 +534,32 @@ export class PillarboxPlaylist extends Plugin {
   static get VERSION() {
     return version;
   }
+
+  handleError() {
+    this.player.clearTimeout(this.skipOnErrorTimeoutId_);
+
+    if (this.skipOnError.enabled) {
+      this.skipOnErrorTimeoutId_ = this.player.setTimeout(() => {
+        const error = this.player.error();
+        const index = this.currentIndex;
+        const item = this.currentItem;
+
+        this.next();
+
+        this.trigger({ type: 'itemskipped', error, index, item });
+      }, this.skipOnError.delay);
+
+    }
+  }
 }
 
 PillarboxPlaylist.prototype.options_ = {
   autoadvance: false,
-  repeat: false
+  repeat: false,
+  skipOnError: {
+    enabled: true,
+    delay: 60
+  }
 };
 
 videojs.registerPlugin('pillarboxPlaylist', PillarboxPlaylist);
@@ -526,4 +578,10 @@ videojs.registerPlugin('pillarboxPlaylist', PillarboxPlaylist);
  *                          and other relevant metadata.
  */
 
-
+/**
+ * Configuration for automatic skipping of playlist items when an error occurs.
+ *
+ * @typedef {Object} SkipOnErrorOptions
+ * @property {boolean} enabled Whether the player should automatically skip to the next playlist item.
+ * @property {number} delay The delay in milliseconds before skipping to the next item after an error.
+ */


### PR DESCRIPTION
## Description

Resolves #121 by introducing a new, configurable skip-on-error feature for the playlist plugin.

This functionality can be enabled or disabled through configuration properties, and the skip delay is configurable as well. An `itemskipped` event is fired whenever an item is skipped, containing the cause, the index of the skipped item, and the item itself.

## Changes Made

- Playlist items that fail are skipped by default.
- The default skip delay is 60 ms and can be adjusted.
- This feature can be disabled via configuration options.
- No visual changes to the `playlist-ui` extension.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
