### PR TITLE
fix(pillarbox-playlist): use load media instead of src

### DIFF
--- a/packages/pillarbox-playlist/README.md
+++ b/packages/pillarbox-playlist/README.md
@@ -79,7 +79,7 @@ The following table outlines the key methods available in this plugin:
 | `next()`                               | Advances to the next item in the playlist, with support for repeat mode.                                                                 |
 | `previous()`                           | Navigates to the previous item or restarts the current item based on playback position and threshold.                                    |
 | `shuffle()`                            | Randomizes the order of the playlist items using the Fisher-Yates shuffle algorithm.                                                     |
-| `select(index)`                        | Selects and plays the item at the specified index in the playlist.                                                                       |
+| `select(index, ready?)`                | Selects and plays the item at the specified index in the playlist.                                                                       |
 | `toggleRepeat(force?)`                 | Cycles through the repeat mode of the player, or sets it to the specified value if provided.                                             |
 | `toggleAutoadvance(force?)`            | Toggles the auto-advance mode of the player to the opposite of its current state, or sets it to the specified boolean value if provided. |
 

--- a/packages/pillarbox-playlist/src/pillarbox-playlist.js
+++ b/packages/pillarbox-playlist/src/pillarbox-playlist.js
@@ -336,9 +336,9 @@ export class PillarboxPlaylist extends Plugin {
    * the playlist this method has no effect.
    *
    * @param {number} index The index of the item to play.
+   * @param {Function} [ready] Optional. A callback to be called when the player is ready.
    */
-  // eslint-disable-next-line max-statements
-  select(index) {
+  select(index, ready = undefined) {
     if (index < 0 || index >= this.items_.length) {
       log.warn(`Index: ${index} is out of bounds (The current playlist has ${this.items_.length} elements)`);
 
@@ -353,8 +353,7 @@ export class PillarboxPlaylist extends Plugin {
 
     const item = this.items_[index];
 
-    this.player.src(item.sources);
-    this.player.poster(item.poster);
+    this.player.loadMedia({ src: item.sources, poster: item.poster }, ready);
     this.currentIndex_ = index;
     this.updateState_();
   }

--- a/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
+++ b/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
@@ -50,6 +50,10 @@ const playlist = [
   }
 ];
 
+function toLoadMediaParams(item) {
+  return [{ src: item.sources, poster: item.poster }, undefined];
+}
+
 window.HTMLMediaElement.prototype.load = () => {
 };
 
@@ -84,9 +88,7 @@ describe('PillarboxPlaylist', () => {
   describe('load', () => {
     it('should load a playlist', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -98,17 +100,14 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(0);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
-      expect(srcSpy).toHaveBeenCalledWith(playlist[0].sources);
-      expect(posterSpy).toHaveBeenCalledWith(playlist[0].poster);
+      expect(loadMediaSpy).toHaveBeenCalledWith(...toLoadMediaParams(playlist[0]));
     });
   });
 
   describe('select', () => {
     it('should select an item by index', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -118,15 +117,12 @@ describe('PillarboxPlaylist', () => {
       // Then
       expect(pillarboxPlaylist.currentIndex).toBe(3);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[3]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[3].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[3].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[3]));
     });
 
     it('should not load an item if its already selected', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -136,17 +132,13 @@ describe('PillarboxPlaylist', () => {
       // Then
       expect(pillarboxPlaylist.currentIndex).toBe(0);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
-      expect(srcSpy).toHaveBeenCalledTimes(1);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[0].sources);
-      expect(posterSpy).toHaveBeenCalledTimes(1);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[0].poster);
+      expect(loadMediaSpy).toHaveBeenCalledTimes(1);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[0]));
     });
 
     it('should not load an item if its outside of the playlist range', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -156,19 +148,15 @@ describe('PillarboxPlaylist', () => {
       // Then
       expect(pillarboxPlaylist.currentIndex).toBe(0);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
-      expect(srcSpy).toHaveBeenCalledTimes(1);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[0].sources);
-      expect(posterSpy).toHaveBeenCalledTimes(1);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[0].poster);
+      expect(loadMediaSpy).toHaveBeenCalledTimes(1);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[0]));
     });
   });
 
   describe('next', () => {
     it('should play next on a registered playlist', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -181,15 +169,12 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(1);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[1]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[1].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[1].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[1]));
     });
 
     it('should not play next if the current index is the last of the playlist', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -203,15 +188,12 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(3);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[3]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[3].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[3].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[3]));
     });
 
     it('should play first element if the current index is the last of the playlist and repeat mode all is enabled', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -226,17 +208,14 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(0);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[0].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[0].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[0]));
     });
   });
 
   describe('previous', () => {
     it('should play previous on a registered playlist', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -250,8 +229,7 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(1);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[1]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[1].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[1].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[1]));
     });
 
     it('should restart the current media if the current time is beyond the threshold', () => {
@@ -274,9 +252,7 @@ describe('PillarboxPlaylist', () => {
 
     it('should not play previous if the current index is the last of the playlist', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -290,15 +266,12 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(0);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[0].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[0].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[0]));
     });
 
     it('should play last element if the current index is the first of the playlist and repeat mode all is enabled', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -313,17 +286,14 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(3);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[3]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[3].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[3].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[3]));
     });
   });
 
   describe('autoadvance', () => {
     it('should play next element on ended if autoadvance is enabled', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -337,15 +307,12 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(1);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[1]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[1].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[1].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[1]));
     });
 
     it('should not play next element on ended if autoadvance is disabled', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -359,8 +326,7 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(0);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[0].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[0].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[0]));
     });
   });
 
@@ -386,9 +352,7 @@ describe('PillarboxPlaylist', () => {
 
     it('should play the first element if repeat is true when next is called and the current index is the last of the playlist', () => {
       // Given
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -403,8 +367,7 @@ describe('PillarboxPlaylist', () => {
       expect(pillarboxPlaylist.items.length).toBe(4);
       expect(pillarboxPlaylist.currentIndex).toBe(0);
       expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[0].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[0].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[0]));
     });
 
     it('should toggle repeat mode', () => {
@@ -753,9 +716,7 @@ describe('PillarboxPlaylist', () => {
       // Given
       const currentTimeSpy = vi.spyOn(player, 'currentTime').mockImplementation(() => {
       });
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -765,8 +726,7 @@ describe('PillarboxPlaylist', () => {
 
       // Then
       expect(pillarboxPlaylist.currentItem).toBe(playlist[3]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[3].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[3].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[3]));
       expect(currentTimeSpy).toHaveBeenLastCalledWith(playlist[3].startTime);
     });
 
@@ -774,9 +734,7 @@ describe('PillarboxPlaylist', () => {
       // Given
       const currentTimeSpy = vi.spyOn(player, 'currentTime').mockImplementation(() => {
       });
-      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
-      });
-      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      const loadMediaSpy = vi.spyOn(player, 'loadMedia').mockImplementation(() => {
       });
 
       // When
@@ -786,8 +744,7 @@ describe('PillarboxPlaylist', () => {
 
       // Then
       expect(pillarboxPlaylist.currentItem).toBe(playlist[2]);
-      expect(srcSpy).toHaveBeenLastCalledWith(playlist[2].sources);
-      expect(posterSpy).toHaveBeenLastCalledWith(playlist[2].poster);
+      expect(loadMediaSpy).toHaveBeenLastCalledWith(...toLoadMediaParams(playlist[2]));
       expect(currentTimeSpy).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Description

Resolves #120 by replacing the usage of `src` with `loadMedia` when a selecting a new item in the playlist.

When using `src` there was undesirable side effect: if an error occured while loading the new media, the previously media may continue playing in the background. Using `loadMedia` avoids this problem altogether.

## Changes Made

- Replace `src` usage by `loadMedia`.
- Adapted tests.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
