### PR TITLE
fix(pillarbox-playlist): pass playlist array correctly in constructor

### DIFF
--- a/packages/pillarbox-playlist/src/pillarbox-playlist.js
+++ b/packages/pillarbox-playlist/src/pillarbox-playlist.js
@@ -162,9 +162,7 @@ export class PillarboxPlaylist extends Plugin {
 
     options = this.options_ = videojs.obj.merge(this.options_, options);
     if (options.playlist && options.playlist.length) {
-      player.ready(() => {
-        this.load(...options.playlist);
-      });
+      player.ready(() => this.load(options.playlist));
     }
 
     this.autoadvance = Boolean(options.autoadvance);

--- a/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
+++ b/packages/pillarbox-playlist/test/pillarbox-playlist.spec.js
@@ -101,6 +101,34 @@ describe('PillarboxPlaylist', () => {
       expect(srcSpy).toHaveBeenCalledWith(playlist[0].sources);
       expect(posterSpy).toHaveBeenCalledWith(playlist[0].poster);
     });
+
+    it('should load a playlist from options', async() => {
+      // Given
+      player.dispose();
+      player = pillarbox(videoElement, {
+        plugins: {
+          pillarboxPlaylist: { playlist },
+        }
+      });
+      pillarboxPlaylist = player.pillarboxPlaylist();
+
+      const srcSpy = vi.spyOn(player, 'src').mockImplementation(() => {
+      });
+      const posterSpy = vi.spyOn(player, 'poster').mockImplementation(() => {
+      });
+
+      // When
+      await new Promise((resolve) => player.ready(() => resolve()));
+
+      // Then
+      expect(pillarboxPlaylist.hasPrevious()).toBeFalsy();
+      expect(pillarboxPlaylist.hasNext()).toBeTruthy();
+      expect(pillarboxPlaylist.items.length).toBe(4);
+      expect(pillarboxPlaylist.currentIndex).toBe(0);
+      expect(pillarboxPlaylist.currentItem).toBe(playlist[0]);
+      expect(srcSpy).toHaveBeenCalledWith(playlist[0].sources);
+      expect(posterSpy).toHaveBeenCalledWith(playlist[0].poster);
+    });
   });
 
   describe('select', () => {


### PR DESCRIPTION
## Description

The constructor was calling `load(...options.playlist)`, incorrectly spreading the playlist items into multiple arguments. Since `load` expects a single array parameter, this resulted in runtime failures when initializing with a playlist.

The call has been corrected to `load(options.playlist)`.

## Changes Made

- Changed : `load(...options.playlist)` to `load(options.playlist)` in the constructor.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
