### PR TITLE
test(user-preferences): vitest linter error

### DIFF
--- a/packages/user-preferences/test/user-preferences.spec.js
+++ b/packages/user-preferences/test/user-preferences.spec.js
@@ -259,9 +259,9 @@ describe('UserPreferences', () => {
       player.userPreferences.restoreTextTrack(textTrack);
 
       tracks.forEach(track => {
-        if (!['metadata', 'chapters'].includes(track.kind)) {
-          expect(track.mode).toBe('disabled');
-        }
+        if (['metadata', 'chapters'].includes(track.kind)) return;
+
+        expect(track.mode).toBe('disabled');
       });
     });
 
@@ -275,9 +275,9 @@ describe('UserPreferences', () => {
       player.userPreferences.restoreTextTrack(textTrack);
 
       tracks.forEach(track => {
-        if (!['metadata', 'chapters'].includes(track.kind)) {
-          expect(track.mode).toBe('disabled');
-        }
+        if (['metadata', 'chapters'].includes(track.kind)) return;
+
+        expect(track.mode).toBe('disabled');
       });
     });
 
@@ -316,9 +316,9 @@ describe('UserPreferences', () => {
       player.userPreferences.restoreTextTrack(textTrack);
 
       tracks.forEach(track => {
-        if (!['metadata', 'chapters'].includes(track.kind)) {
-          expect(track.mode).toBe('disabled');
-        }
+        if (['metadata', 'chapters'].includes(track.kind)) return;
+
+        expect(track.mode).toBe('disabled');
       });
     });
 


### PR DESCRIPTION
## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

Sometimes, but not always, the linter appears to cause the tests to fail with the following message:

```
Avoid calling `expect` inside conditional statements
```

So, to avoid this error the condition was reversed in the affected tests.

refer to: https://github.com/SRGSSR/pillarbox-web-suite/actions/runs/21449912840/job/61776280628


## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
