### PR TITLE
fix: use correct path for google cast button component

### DIFF
--- a/packages/google-cast-sender/package.json
+++ b/packages/google-cast-sender/package.json
@@ -22,8 +22,8 @@
       "require": "./dist/google-cast-sender.cjs"
     },
     "./button": {
-      "import": "./dist/ui/google-cast-button.js",
-      "require": "./dist/ui/google-cast-button.cjs"
+      "import": "./dist/button/google-cast-button.js",
+      "require": "./dist/button/google-cast-button.cjs"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
## Description

The `/button` export for the `GoogleCastButton` points to a file that does not exist as the path is no longer valid. 

## Changes Made

This PR updates the path from `/dist/ui` to `/dist/button` as that's where the files are now built when `npm run build` is executed.

<img width="870" height="724" alt="Screenshot 2026-02-23 at 11 52 39" src="https://github.com/user-attachments/assets/a98a1173-f938-4d2f-8cc7-50f8826de00a" />

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
