### PR TITLE
feat(srg-ssr-hotkeys): allow configurable seek amounts for arrow keys

### DIFF
--- a/packages/srg-ssr-hotkeys/README.md
+++ b/packages/srg-ssr-hotkeys/README.md
@@ -55,13 +55,17 @@ document.body.addEventListener('keydown', keydown);
 
 | Key(s) | Action | Notes |
 | --- | ---: | ---: |
-| ArrowRight | Seek forward 30 seconds | No-op if at live edge and stream is live |
-| ArrowLeft | Seek backward 10 seconds | |
-| 0–9 (number keys) | Seek to 0%–90% of duration | 0 = 0%, 1 = 10%, ..., 9 = 90% |
+| ArrowRight | Seek forward (configurable, default 30 seconds) | Uses [`skipButtons.backward`](https://legacy.videojs.org/guides/options/#skipbuttonsbackward) (default 30s); no-op if at live edge and stream is live |
+| ArrowLeft | Seek backward (configurable, default 10 seconds) | Uses [`skipButtons.backward`](https://legacy.videojs.org/guides/options/#skipbuttonsforward) (default 10s) |
+| 0–9 (number keys) | Seek to 0% - 90% of duration | 0 = 0%, 1 = 10%, ..., 9 = 90% |
 | p / P | Toggle play / pause | |
 | + or ArrowUp | Increase volume by 0.1 (10%) | Volume is clamped by player; unmutes if volume > 0 |
 | - or ArrowDown | Decrease volume by 0.1 (10%) | Player is muted if volume ≤ 0 |
 | Default Video.js hotkeys | Includes all built-in [Video.js shortcuts](https://legacy.videojs.org/guides/options/#useractionshotkeys) | Handled via player.handleHotkeys(event) |
+
+> [!WARNING]
+> By changing the default seek-amount values, developers take on the
+> responsibility of deviating from the SRG SSR specification.
 
 ## Contributing
 

--- a/packages/srg-ssr-hotkeys/src/srg-ssr-hotkeys.js
+++ b/packages/srg-ssr-hotkeys/src/srg-ssr-hotkeys.js
@@ -50,7 +50,7 @@ class HotkeysHelper {
   static seek(player, event) {
     if (!HotkeysHelper.#isArrowKey(event)) return;
 
-    const seekAmount = HotkeysHelper.#seekAmount(event);
+    const seekAmount = HotkeysHelper.#seekAmount(player, event);
     const seekPosition = player.currentTime() + seekAmount;
 
     if (
@@ -168,12 +168,27 @@ class HotkeysHelper {
   /**
    * Computes the amount of seconds to seek based on the specific arrow key.
    *
+   * @param {import('video.js/dist/types/player.js').default} player the player instance
    * @param {KeyboardEvent} event the keyboard event object
    *
    * @returns {number} -10 for 'ArrowLeft' or 30 for 'ArrowRight'
    */
-  static #seekAmount(event) {
-    return event.key === 'ArrowLeft' ? -10 : 30;
+  static #seekAmount(player, event) {
+    const {
+      controlBar : {
+        skipButtons : {
+          backward = 10,
+          forward = 30,
+        } = {}
+      } = {}
+    } = player.options();
+
+    const seekValues = {
+      ArrowLeft: (backward * -1),
+      ArrowRight: forward,
+    };
+
+    return seekValues[event.key];
   }
 }
 

--- a/packages/srg-ssr-hotkeys/test/srg-ssr-hotkeys.spec.js
+++ b/packages/srg-ssr-hotkeys/test/srg-ssr-hotkeys.spec.js
@@ -18,6 +18,7 @@ describe('HotkeysHelper', () => {
       duration: vi.fn().mockReturnValue(100),
       muted: vi.fn(),
       handleHotkeys: vi.fn(),
+      options: vi.fn().mockReturnValue({}),
 
       volume: vi.fn((val) => {
         if (val !== undefined) currentVolume = val;
@@ -85,11 +86,43 @@ describe('HotkeysHelper', () => {
       expect(playerMock.currentTime).toHaveBeenCalledWith(40);
     });
 
+    it('should seek backward to the configured value when ArrowLeft is pressed', () => {
+      eventMock.key = 'ArrowLeft';
+
+      playerMock.options.mockReturnValueOnce({
+        controlBar: {
+          skipButtons: {
+            backward: 5,
+          },
+        },
+      });
+
+      HotkeysHelper.seek(playerMock, eventMock);
+
+      expect(playerMock.currentTime).toHaveBeenCalledWith(45);
+    });
+
     it('should seek forward 30 seconds when ArrowRight is pressed', () => {
       eventMock.key = 'ArrowRight';
       HotkeysHelper.seek(playerMock, eventMock);
 
       expect(playerMock.currentTime).toHaveBeenCalledWith(80);
+    });
+
+    it('should seek forward to the configured value when ArrowRight is pressed', () => {
+      eventMock.key = 'ArrowRight';
+
+      playerMock.options.mockReturnValueOnce({
+        controlBar: {
+          skipButtons: {
+            forward: 5,
+          },
+        },
+      });
+
+      HotkeysHelper.seek(playerMock, eventMock);
+
+      expect(playerMock.currentTime).toHaveBeenCalledWith(55);
     });
 
     it('should clamp seek position to 0 if seeking backward past the beginning', () => {


### PR DESCRIPTION
## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

Updates the hotkey functionality to allow custom seek amounts for the `ArrowLeft` and `ArrowRight` keys. The seek amounts are now retrieved from the player's `controlBar.skipButtons` options, defaulting to 10 seconds backward and 30 seconds forward if not specified.

> [!WARNING]
> By changing the default seek-amount values, developers take on the
> responsibility of deviating from the SRG SSR specification.

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- update `README.md` to reflect configurable seek amounts
- modify `HotkeysHelper.#seekAmount` to use player options
- add tests for configurable seek values

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
