### PR TITLE
fix(google-cast-sender): poster update

### DIFF
--- a/packages/google-cast-sender/src/google-cast-tech.js
+++ b/packages/google-cast-sender/src/google-cast-tech.js
@@ -457,6 +457,12 @@ class Chromecast extends Tech {
     return this.getMediaSession() ? this.getMediaSession().playbackRate : 1;
   }
 
+  setPoster(src) {
+    if (!this.el()) return;
+
+    this.el().style = `background-image: url("${src}")`;
+  }
+
   poster() {
     const remotePoster = this.remotePlayer && this.remotePlayer.imageUrl;
 

--- a/packages/google-cast-sender/test/google-cast-tech.spec.js
+++ b/packages/google-cast-sender/test/google-cast-tech.spec.js
@@ -62,6 +62,24 @@ describe('Chromecast', () => {
     });
   });
 
+  describe('setPoster', () => {
+    it('should do nothing if el() returns falsy', () => {
+      vi.spyOn(tech, 'el').mockReturnValue(null);
+
+      expect(() => tech.setPoster('https://test.url/poster.jpg')).not.toThrow();
+    });
+
+    it('should set the background image style on the tech element', () => {
+      const mockEl = { style: '' };
+
+      vi.spyOn(tech, 'el').mockReturnValue(mockEl);
+
+      tech.setPoster('https://test.url/poster.jpg');
+
+      expect(mockEl.style).toBe('background-image: url("https://test.url/poster.jpg")');
+    });
+  });
+
   describe('loadMedia', () => {
     it('should handle loadMedia error', async() => {
       const error = new Error('error');


### PR DESCRIPTION
## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

When loading a new media item, the poster image was not being updated and therefore kept the reference to the poster of the very first media loaded.

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- add `setPoster` to allow updating the poster when the media changes
- add test cases

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
