### PR TITLE
fix(google-cast-sender): null-safe control bar

### DIFF
--- a/packages/google-cast-sender/src/google-cast-tech.js
+++ b/packages/google-cast-sender/src/google-cast-tech.js
@@ -50,7 +50,7 @@ class Chromecast extends Tech {
 
     this.localPlayer = videojs(options.playerId);
     this.localPlayer.addClass('vjs-chromecast-connected');
-    this.localPlayer.controlBar.lockShowing();
+    this.localPlayer.controlBar?.lockShowing();
   }
 
   /**
@@ -393,7 +393,7 @@ class Chromecast extends Tech {
     }
 
     if (this.localPlayer) {
-      this.localPlayer.controlBar.unlockShowing();
+      this.localPlayer.controlBar?.unlockShowing();
       this.localPlayer.removeClass('vjs-chromecast-connected');
     }
 


### PR DESCRIPTION
## Description

When a custom player layout omits the top-level control bar, the Google Cast tech crashed because it called `lockShowing()` / `unlockShowing()` on `controlBar` unconditionally. This change makes those calls null-safe so integrators can use custom layouts without needing a stub control bar.

## Changes Made

- Make `controlBar.lockShowing()` and `controlBar.unlockShowing()` calls null-safe in `google-cast-tech.js`

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
