### PR TITLE
fix(airplay-button): display consistency

### DIFF
--- a/packages/airplay-button/src/airplay-button.js
+++ b/packages/airplay-button/src/airplay-button.js
@@ -14,20 +14,6 @@ const SvgButton = videojs.getComponent('SvgButton');
  */
 class AirplayButton extends SvgButton {
   /**
-   * Listener for detecting AirPlay device availability.
-   * If an AirPlay device is available, the button is shown.
-   *
-   * @param {{ availability: string }} event - The event object with availability info.
-   */
-  #onWebkitPlaybackTargetAvailabilityChangedListener = ({ availability }) => {
-    if (availability === 'available') {
-      this.show();
-    } else if (availability === 'not-available') {
-      this.hide();
-    }
-  };
-
-  /**
    * The media element associated to the player.
    *
    * @type {HTMLMediaElement|null}
@@ -46,10 +32,6 @@ class AirplayButton extends SvgButton {
   }
 
   dispose() {
-    this.#mediaElement?.removeEventListener(
-      'webkitplaybacktargetavailabilitychanged',
-      this.#onWebkitPlaybackTargetAvailabilityChangedListener
-    );
     this.#mediaElement = null;
 
     super.dispose();
@@ -61,14 +43,13 @@ class AirplayButton extends SvgButton {
    */
   init() {
     if (!AirplayButton.isAirplaySupported()) {
+       this.hide();
+
       return;
     }
 
-    this.#mediaElement = this.player().el().querySelector('audio, video');
-    this.#mediaElement.addEventListener(
-      'webkitplaybacktargetavailabilitychanged',
-      this.#onWebkitPlaybackTargetAvailabilityChangedListener
-    );
+    this.#mediaElement = this.player().tech(true).el();
+    this.show();
   }
 
   /**

--- a/packages/airplay-button/test/airplay-button.spec.js
+++ b/packages/airplay-button/test/airplay-button.spec.js
@@ -41,8 +41,11 @@ describe('AirplayButton', () => {
 
 
   describe('Airplay supported', () => {
+    let initSpy;
+
     beforeAll(() => {
       window.WebKitPlaybackTargetAvailabilityEvent = true;
+      initSpy = vi.spyOn(AirplayButton.prototype, 'init');
     });
 
     beforeEach(async() => {
@@ -56,6 +59,7 @@ describe('AirplayButton', () => {
 
     afterEach(() => {
       player.dispose();
+      initSpy.mockClear();
     });
 
     it('should be registered and attached to the player', () => {
@@ -64,23 +68,10 @@ describe('AirplayButton', () => {
       expect(AirplayButton.VERSION).toBeDefined();
     });
 
-    it('should display the button according to the availability event', () => {
-      const event = new Event('webkitplaybacktargetavailabilitychanged');
-
-      // The button starts hidden despite compatibility
-      expect(player.airplayButton.hasClass('vjs-hidden')).toBeTruthy();
-
-      event.availability = 'available';
-      videoElement.dispatchEvent(event);
-
-      // The button becomes visible after AirPlay is available
+    it('should display the button if WebKitPlaybackTargetAvailabilityEvent is truthy', () => {
+      // The button becomes visible
+      expect(initSpy).toHaveBeenCalled();
       expect(player.airplayButton.hasClass('vjs-hidden')).toBeFalsy();
-
-      event.availability = 'not-available';
-      videoElement.dispatchEvent(event);
-
-      // The button becomes hidden after AirPlay is no longer available
-      expect(player.airplayButton.hasClass('vjs-hidden')).toBeTruthy();
     });
 
     it('should display the device picker when the button is clicked', () => {


### PR DESCRIPTION
## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

Today, the `airplay-button` component is displayed when a `webkitplaybacktargetavailabilitychanged` event occurs, and the `availability` property is set to the value `available`.

Even though best practice would be to show the button only when the `availability` property changes to `available`, the issue is that it sometimes updates intermittently, causing the AirPlay button to appear and disappear erratically.

So, to provide a more consistent experience, if a
`WebKitPlaybackTargetAvailabilityEvent` exists, we display the button. Even if the user clicks the AirPlay button, the only target they will see is their own machine.

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- remove the `webkitplaybacktargetavailabilitychanged` event handler
- update the unit tests

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
