### PR TITLE
fix(chapter-bar): chapter availatiblity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4526,9 +4526,9 @@
       "link": true
     },
     "node_modules/@srgssr/pillarbox-web": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@srgssr/pillarbox-web/-/pillarbox-web-1.31.0.tgz",
-      "integrity": "sha512-wn1IcZlmiF+ho1BI+d7Oz26FBUEXwTLfDfPbFv6jeEGfb+CBnMDlBk5AvEyRup5+kjwfoQKzIF/V1+gtFhYvJQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/@srgssr/pillarbox-web/-/pillarbox-web-1.36.1.tgz",
+      "integrity": "sha512-rx5gi/vl24ofYND9Vuw6A6ds6476ka4BEh0kA7Q78zWRdaRqlZTC5ArVcqy7B0vshzU+x0eVPP3fwTARz8MBIg==",
       "license": "MIT",
       "dependencies": {
         "videojs-contrib-eme": "5.5.2"
@@ -21137,7 +21137,7 @@
     },
     "packages/airplay-button": {
       "name": "@srgssr/airplay-button",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@srgssr/svg-button": "^1.0.0"
@@ -21193,7 +21193,7 @@
         "@srgssr/card": "^1.0.0"
       },
       "peerDependencies": {
-        "@srgssr/pillarbox-web": "^1.24.1"
+        "@srgssr/pillarbox-web": "^1.36.1"
       }
     },
     "packages/countdown-display": {
@@ -21209,7 +21209,7 @@
     },
     "packages/google-cast-sender": {
       "name": "@srgssr/google-cast-sender",
-      "version": "1.2.4",
+      "version": "1.2.6",
       "license": "MIT",
       "dependencies": {
         "@srgssr/svg-button": "^1.1.0"
@@ -21246,7 +21246,7 @@
     },
     "packages/pillarbox-playlist": {
       "name": "@srgssr/pillarbox-playlist",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@srgssr/card": "^1.0.0",
@@ -21269,7 +21269,7 @@
     },
     "packages/srg-ssr-hotkeys": {
       "name": "@srgssr/srg-ssr-hotkeys",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT"
     },
     "packages/svg-button": {

--- a/packages/chapters-bar/package.json
+++ b/packages/chapters-bar/package.json
@@ -47,6 +47,6 @@
     "@srgssr/card": "^1.0.0"
   },
   "peerDependencies": {
-    "@srgssr/pillarbox-web": "^1.24.1"
+    "@srgssr/pillarbox-web": "^1.36.1"
   }
 }

--- a/packages/chapters-bar/src/chapters-bar.js
+++ b/packages/chapters-bar/src/chapters-bar.js
@@ -43,7 +43,7 @@ class ChaptersBar extends Component {
     this.onChapterChange = this.onChapterChange.bind(this);
     this.userActive = this.userActive.bind(this);
 
-    this.player().textTracks().on('addtrack', this.onAddChaptersTrack);
+    this.player().on('loadeddata', this.onAddChaptersTrack);
     this.player().on('emptied', this.onEmptied);
     this.player().on('useractive', this.userActive);
     this.player().on('srgssr/chapter', this.onChapterChange);
@@ -196,8 +196,8 @@ class ChaptersBar extends Component {
    *
    * @private
    */
-  onAddChaptersTrack({ track }) {
-    if (!track || track.id !== 'srgssr-chapters') return;
+  onAddChaptersTrack() {
+    if (!this.player().textTracks().getTrackById('srgssr-chapters')) return;
 
     const chapters = this.chapters();
 

--- a/packages/chapters-bar/test/chapters-bar.spec.js
+++ b/packages/chapters-bar/test/chapters-bar.spec.js
@@ -102,6 +102,8 @@ describe('ChaptersBar', () => {
     });
 
     it('should do nothing if there are no chapters', () => {
+      player.textTracks().getTrackById.mockReturnValueOnce(null);
+
       const chaptersBar = new ChaptersBar(player, { chapterOptions: {} });
       const addChapterSpy = vi.spyOn(chaptersBar, 'addChapter');
 


### PR DESCRIPTION


## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

The change introduced by fix [#406](https://github.com/SRGSSR/pillarbox-web/pull/406) prevents the chapter bar from being displayed because the text track doesn't contain the VTTCue yet.

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- listen to the `loadeddata` event instead of `addtrack` so the chapters are shown
- update the test case
- update pillarbox-web to the latest version

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
