### PR TITLE
fix(airplay-button): force component release by updating player version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21143,7 +21143,7 @@
         "@srgssr/svg-button": "^1.0.0"
       },
       "devDependencies": {
-        "@srgssr/pillarbox-web": "^1.24.1"
+        "@srgssr/pillarbox-web": "^1.36.1"
       },
       "peerDependencies": {
         "video.js": "^8.0.0"
@@ -21187,7 +21187,7 @@
     },
     "packages/chapters-bar": {
       "name": "@srgssr/chapters-bar",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@srgssr/card": "^1.0.0"

--- a/packages/airplay-button/package.json
+++ b/packages/airplay-button/package.json
@@ -50,6 +50,6 @@
     "video.js": "^8.0.0"
   },
   "devDependencies": {
-    "@srgssr/pillarbox-web": "^1.24.1"
+    "@srgssr/pillarbox-web": "^1.36.1"
   }
 }


### PR DESCRIPTION

## Description

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

This commit is marked as a `fix` so that a new package can be generated, since the previous generation failed due to OIDC not being configured.


## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- to force the generation of a new package, the player version was updated in `package.json`
- update root `package-lock` file

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
