### PR TITLE
ci: reduce dependabot noise in previews and updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # Conventional Commits type, so commitlint and semantic-release parse the PRs.
     commit-message:
       prefix: "ci"
     groups:
@@ -23,9 +22,11 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build"
-    # Internal workspace packages are versioned by semantic-release.
+    # Internal workspace packages are versioned by semantic-release, video.js is
+    # manually updated.
     ignore:
       - dependency-name: "@srgssr/*"
+      - dependency-name: "video.js"
     groups:
       node-dependencies:
         patterns:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,7 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Description

Skip the preview deployment for pull requests triggered by dependabot.
Ignore `video.js` in the npm dependabot configuration, as it is updated manually rather than through automated bumps.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
