### PR TITLE
fix(google-cast-sender): default cast launcher when player is disposed

### DIFF
--- a/packages/google-cast-sender/src/google-cast-sender.js
+++ b/packages/google-cast-sender/src/google-cast-sender.js
@@ -137,6 +137,11 @@ class GoogleCastSender extends Plugin {
    * @private
    */
   removeDefaultCastLauncher() {
+    if (
+      !this.#options.enableDefaultCastLauncher ||
+      !this.player.controlBar
+    ) return;
+
     this.player.controlBar.removeChild('GoogleCastLauncher');
   }
 


### PR DESCRIPTION



## Description

Resolves #176 by removing the error that occurs when the player is disposed and the player has no control bar.
<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- add a short-circuit in `removeDefaultCastLauncher`

## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
